### PR TITLE
Add initial permissions prompt

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,27 +1,50 @@
-import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import React from 'react';
+import { BrowserRouter, Routes, Route, useLocation, useNavigate } from 'react-router-dom';
 import NavBar from './components/NavBar';
 import Home from './pages/Home';
 import About from './pages/About';
 import WelcomeCarousel from './components/WelcomeCarousel';
 import { useThemeStore } from './contexts/useThemeStore';
+import PermissionsPrompt from './components/PermissionsPrompt';
+import { usePermissionStore } from './contexts/usePermissionStore';
 import './index.css';
 
-function App() {
+function InnerApp() {
   const { dark, toggle } = useThemeStore();
+  const { shown } = usePermissionStore();
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  React.useEffect(() => {
+    if (
+      !shown &&
+      location.pathname !== '/permissions' &&
+      location.pathname !== '/'
+    ) {
+      navigate('/permissions', { replace: true });
+    }
+  }, [shown, location.pathname, navigate]);
 
   return (
+    <div className={dark ? 'dark min-h-screen bg-gray-900 text-white' : 'min-h-screen bg-white text-gray-900'}>
+      <button onClick={toggle} className="m-4 p-2 border rounded">
+        Toggle Theme
+      </button>
+      <NavBar />
+      <Routes>
+        <Route path="/" element={<WelcomeCarousel />} />
+        <Route path="/permissions" element={<PermissionsPrompt />} />
+        <Route path="/home" element={<Home />} />
+        <Route path="/about" element={<About />} />
+      </Routes>
+    </div>
+  );
+}
+
+function App() {
+  return (
     <BrowserRouter>
-      <div className={dark ? 'dark min-h-screen bg-gray-900 text-white' : 'min-h-screen bg-white text-gray-900'}>
-        <button onClick={toggle} className="m-4 p-2 border rounded">
-          Toggle Theme
-        </button>
-        <NavBar />
-        <Routes>
-          <Route path="/" element={<WelcomeCarousel />} />
-          <Route path="/home" element={<Home />} />
-          <Route path="/about" element={<About />} />
-        </Routes>
-      </div>
+      <InnerApp />
     </BrowserRouter>
   );
 }

--- a/src/components/PermissionsPrompt.tsx
+++ b/src/components/PermissionsPrompt.tsx
@@ -1,0 +1,41 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { usePermissionStore } from '../contexts/usePermissionStore';
+
+export default function PermissionsPrompt() {
+  const { setShown } = usePermissionStore();
+  const navigate = useNavigate();
+  const [requesting, setRequesting] = useState(false);
+
+  const requestPermissions = () => {
+    setRequesting(true);
+    Notification.requestPermission().finally(() => {
+      navigator.geolocation.getCurrentPosition(
+        () => {
+          setShown(true);
+          navigate('/home');
+        },
+        () => {
+          setShown(true);
+          navigate('/home');
+        }
+      );
+    });
+  };
+
+  return (
+    <div className="flex flex-col items-center justify-center h-screen p-4 text-center">
+      <h1 className="text-2xl font-bold mb-2">Enable Permissions</h1>
+      <p className="mb-4">
+        We use notifications and your location to enhance your experience.
+      </p>
+      <button
+        onClick={requestPermissions}
+        disabled={requesting}
+        className="px-4 py-2 bg-primary text-white rounded"
+      >
+        {requesting ? 'Requesting...' : 'Allow'}
+      </button>
+    </div>
+  );
+}

--- a/src/components/WelcomeCarousel.tsx
+++ b/src/components/WelcomeCarousel.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { AnimatePresence, motion } from 'framer-motion';
 import { useNavigate } from 'react-router-dom';
+import { usePermissionStore } from '../contexts/usePermissionStore';
 
 interface Slide {
   title: string;
@@ -34,16 +35,17 @@ const slides: Slide[] = [
 export default function WelcomeCarousel() {
   const [index, setIndex] = useState(0);
   const navigate = useNavigate();
+  const { shown } = usePermissionStore();
 
   const next = () => {
     if (index < slides.length - 1) {
       setIndex(index + 1);
     } else {
-      navigate('/home');
+      navigate(shown ? '/home' : '/permissions');
     }
   };
 
-  const skip = () => navigate('/home');
+  const skip = () => navigate(shown ? '/home' : '/permissions');
 
   return (
     <div className="flex flex-col items-center justify-center h-screen p-4 text-center">

--- a/src/contexts/usePermissionStore.ts
+++ b/src/contexts/usePermissionStore.ts
@@ -1,0 +1,16 @@
+import { create } from 'zustand';
+
+interface PermissionState {
+  shown: boolean;
+  setShown: (val: boolean) => void;
+}
+
+const initialShown = localStorage.getItem('permissionsPromptShown') === 'true';
+
+export const usePermissionStore = create<PermissionState>((set) => ({
+  shown: initialShown,
+  setShown: (val) => {
+    localStorage.setItem('permissionsPromptShown', String(val));
+    set({ shown: val });
+  },
+}));


### PR DESCRIPTION
## Summary
- add zustand store to remember whether permissions were requested
- implement `PermissionsPrompt` component to request notification and geolocation
- route through the permissions page on first load or after the welcome carousel

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68508769b12c832fb5d629da35184c21