### PR TITLE
Add customization page and persistent settings

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { BrowserRouter, Routes, Route, useLocation, useNavigate } from 'react-ro
 import NavBar from './components/NavBar';
 import Home from './pages/Home';
 import About from './pages/About';
+import Customize from './pages/Customize';
 import WelcomeCarousel from './components/WelcomeCarousel';
 import { useThemeStore } from './contexts/useThemeStore';
 import PermissionsPrompt from './components/PermissionsPrompt';
@@ -36,6 +37,7 @@ function InnerApp() {
         <Route path="/permissions" element={<PermissionsPrompt />} />
         <Route path="/home" element={<Home />} />
         <Route path="/about" element={<About />} />
+        <Route path="/customize" element={<Customize />} />
       </Routes>
     </div>
   );

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -2,9 +2,10 @@ import { Link } from 'react-router-dom';
 
 export default function NavBar() {
   return (
-      <nav className="flex gap-4 p-4 bg-gray-200 dark:bg-gray-800">
-        <Link to="/home" className="text-blue-600 dark:text-blue-400">Home</Link>
-        <Link to="/about" className="text-blue-600 dark:text-blue-400">About</Link>
-      </nav>
+    <nav className="flex gap-4 p-4 bg-gray-200 dark:bg-gray-800">
+      <Link to="/home" className="text-blue-600 dark:text-blue-400">Home</Link>
+      <Link to="/about" className="text-blue-600 dark:text-blue-400">About</Link>
+      <Link to="/customize" className="text-blue-600 dark:text-blue-400">Customize</Link>
+    </nav>
   );
 }

--- a/src/contexts/useThemeStore.ts
+++ b/src/contexts/useThemeStore.ts
@@ -2,10 +2,36 @@ import { create } from 'zustand';
 
 interface ThemeState {
   dark: boolean;
+  season: string;
+  notificationFrequency: number;
   toggle: () => void;
+  setSeason: (season: string) => void;
+  setNotificationFrequency: (frequency: number) => void;
 }
 
+const initialDark = localStorage.getItem('themeDark') === 'true';
+const initialSeason = localStorage.getItem('seasonPreference') || 'Spring';
+const initialFrequency = parseInt(
+  localStorage.getItem('notificationFrequency') || '5',
+  10
+);
+
 export const useThemeStore = create<ThemeState>((set) => ({
-  dark: false,
-  toggle: () => set((state) => ({ dark: !state.dark })),
+  dark: initialDark,
+  season: initialSeason,
+  notificationFrequency: initialFrequency,
+  toggle: () =>
+    set((state) => {
+      const value = !state.dark;
+      localStorage.setItem('themeDark', String(value));
+      return { dark: value };
+    }),
+  setSeason: (season) => {
+    localStorage.setItem('seasonPreference', season);
+    set({ season });
+  },
+  setNotificationFrequency: (frequency) => {
+    localStorage.setItem('notificationFrequency', String(frequency));
+    set({ notificationFrequency: frequency });
+  },
 }));

--- a/src/pages/Customize.tsx
+++ b/src/pages/Customize.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { useThemeStore } from '../contexts/useThemeStore';
+
+export default function Customize() {
+  const {
+    dark,
+    toggle,
+    season,
+    setSeason,
+    notificationFrequency,
+    setNotificationFrequency,
+  } = useThemeStore();
+
+  return (
+    <div className="p-4 space-y-6">
+      <h1 className="text-2xl font-bold">Customize Settings</h1>
+
+      <div className="flex items-center gap-2">
+        <label htmlFor="dark-toggle">Dark Mode</label>
+        <input
+          id="dark-toggle"
+          type="checkbox"
+          checked={dark}
+          onChange={toggle}
+        />
+      </div>
+
+      <div>
+        <label htmlFor="season-select" className="block mb-1">
+          Seasonal Preference
+        </label>
+        <select
+          id="season-select"
+          value={season}
+          onChange={(e) => setSeason(e.target.value)}
+          className="p-2 border rounded text-black"
+        >
+          <option value="Spring">Spring</option>
+          <option value="Summer">Summer</option>
+          <option value="Autumn">Autumn</option>
+          <option value="Winter">Winter</option>
+        </select>
+      </div>
+
+      <div>
+        <label htmlFor="notification-range" className="block mb-1">
+          Notification Frequency: {notificationFrequency}
+        </label>
+        <input
+          id="notification-range"
+          type="range"
+          min="0"
+          max="10"
+          value={notificationFrequency}
+          onChange={(e) => setNotificationFrequency(Number(e.target.value))}
+          className="w-full"
+        />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- extend `useThemeStore` to store season and notification frequency
- persist theme preferences to localStorage
- add new `Customize` page with UI controls
- link Customize in navbar and route

## Testing
- `npm run lint` *(fails: Cannot find module '@eslint/js')*
- `npm run build` *(fails: Cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_685088bb68b4832fa2547fa4237a3a51