### PR TITLE
Fix dark mode text visibility

### DIFF
--- a/src/pages/Customize.tsx
+++ b/src/pages/Customize.tsx
@@ -32,7 +32,7 @@ export default function Customize() {
           id="season-select"
           value={season}
           onChange={(e) => setSeason(e.target.value)}
-          className="p-2 border rounded text-black"
+          className="p-2 border rounded text-gray-900 dark:text-white"
         >
           <option value="Spring">Spring</option>
           <option value="Summer">Summer</option>


### PR DESCRIPTION
## Summary
- ensure text in the seasonal preference dropdown is visible in both light and dark themes

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68508d2dd7d0832fb8247328a41a3990