### PR TITLE
Handle missing Notification and geolocation support

### DIFF
--- a/src/components/PermissionsPrompt.tsx
+++ b/src/components/PermissionsPrompt.tsx
@@ -7,7 +7,16 @@ export default function PermissionsPrompt() {
   const navigate = useNavigate();
   const [requesting, setRequesting] = useState(false);
 
+  const notificationsSupported =
+    typeof window !== 'undefined' && 'Notification' in window;
+  const geolocationSupported =
+    typeof navigator !== 'undefined' && 'geolocation' in navigator;
+
   const requestPermissions = () => {
+    if (!notificationsSupported || !geolocationSupported) {
+      return;
+    }
+
     setRequesting(true);
     Notification.requestPermission().finally(() => {
       navigator.geolocation.getCurrentPosition(
@@ -29,9 +38,21 @@ export default function PermissionsPrompt() {
       <p className="mb-4">
         We use notifications and your location to enhance your experience.
       </p>
+      {!notificationsSupported && (
+        <p className="mb-2 text-red-500">
+          Notifications are not supported by your browser.
+        </p>
+      )}
+      {!geolocationSupported && (
+        <p className="mb-2 text-red-500">
+          Geolocation is not supported by your browser.
+        </p>
+      )}
       <button
         onClick={requestPermissions}
-        disabled={requesting}
+        disabled={
+          requesting || !notificationsSupported || !geolocationSupported
+        }
         className="px-4 py-2 bg-primary text-white rounded"
       >
         {requesting ? 'Requesting...' : 'Allow'}


### PR DESCRIPTION
## Summary
- check if the browser supports Notifications and geolocation
- disable permission request button if APIs are unavailable
- show user messages when Notification or geolocation is missing

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68508dee59a4832faa129ca11114f818