### PR TITLE
Add mood entry page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import NavBar from './components/NavBar';
 import Home from './pages/Home';
 import About from './pages/About';
 import Customize from './pages/Customize';
+import MoodEntry from './pages/MoodEntry';
 import WelcomeCarousel from './components/WelcomeCarousel';
 import { useThemeStore } from './contexts/useThemeStore';
 import PermissionsPrompt from './components/PermissionsPrompt';
@@ -38,6 +39,7 @@ function InnerApp() {
         <Route path="/home" element={<Home />} />
         <Route path="/about" element={<About />} />
         <Route path="/customize" element={<Customize />} />
+        <Route path="/mood" element={<MoodEntry />} />
       </Routes>
     </div>
   );

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -6,6 +6,7 @@ export default function NavBar() {
       <Link to="/home" className="text-blue-600 dark:text-blue-400">Home</Link>
       <Link to="/about" className="text-blue-600 dark:text-blue-400">About</Link>
       <Link to="/customize" className="text-blue-600 dark:text-blue-400">Customize</Link>
+      <Link to="/mood" className="text-blue-600 dark:text-blue-400">Mood</Link>
     </nav>
   );
 }

--- a/src/pages/MoodEntry.tsx
+++ b/src/pages/MoodEntry.tsx
@@ -1,0 +1,93 @@
+import { useState } from 'react';
+
+const moodEmojis = ['\uD83D\uDE22', '\uD83D\uDE41', '\uD83D\uDE10', '\uD83D\uDE42', '\uD83D\uDE04'];
+
+export default function MoodEntry() {
+  const [mood, setMood] = useState(3);
+  const [energy, setEnergy] = useState(5);
+  const [sleep, setSleep] = useState(5);
+  const [light, setLight] = useState(5);
+  const [notes, setNotes] = useState('');
+
+  return (
+    <div className="p-4 space-y-6">
+      <h1 className="text-2xl font-bold">Mood Entry</h1>
+
+      <div>
+        <p className="mb-2">How are you feeling today?</p>
+        <div className="flex items-center gap-3">
+          {moodEmojis.map((emoji, index) => (
+            <button
+              key={emoji}
+              onClick={() => setMood(index + 1)}
+              className={
+                'text-3xl transition transform ' +
+                (mood === index + 1 ? 'scale-125' : 'opacity-50')
+              }
+            >
+              {emoji}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div>
+        <label htmlFor="energy" className="block mb-1">
+          Energy Level: {energy}
+        </label>
+        <input
+          id="energy"
+          type="range"
+          min="1"
+          max="10"
+          value={energy}
+          onChange={(e) => setEnergy(Number(e.target.value))}
+          className="w-full"
+        />
+      </div>
+
+      <div>
+        <label htmlFor="sleep" className="block mb-1">
+          Sleep Quality: {sleep}
+        </label>
+        <input
+          id="sleep"
+          type="range"
+          min="1"
+          max="10"
+          value={sleep}
+          onChange={(e) => setSleep(Number(e.target.value))}
+          className="w-full"
+        />
+      </div>
+
+      <div>
+        <label htmlFor="light" className="block mb-1">
+          Light Exposure: {light}
+        </label>
+        <input
+          id="light"
+          type="range"
+          min="1"
+          max="10"
+          value={light}
+          onChange={(e) => setLight(Number(e.target.value))}
+          className="w-full"
+        />
+      </div>
+
+      <div>
+        <label htmlFor="notes" className="block mb-1">
+          Notes (optional)
+        </label>
+        <textarea
+          id="notes"
+          value={notes}
+          onChange={(e) => setNotes(e.target.value)}
+          className="w-full p-2 border rounded text-gray-900 dark:text-white"
+          rows={4}
+        />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- capture mood with a 5-emoji picker and sliders for energy, sleep and light exposure
- hook the new `MoodEntry` page into the router
- link to the page from the NavBar

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685093035938832f984642e99d7994db