### PR TITLE
Add check-in reminder store and modal

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,13 +9,16 @@ import WelcomeCarousel from './components/WelcomeCarousel';
 import { useThemeStore } from './contexts/useThemeStore';
 import PermissionsPrompt from './components/PermissionsPrompt';
 import { usePermissionStore } from './contexts/usePermissionStore';
+import { useCheckInStore } from './contexts/useCheckInStore';
 import './index.css';
 
 function InnerApp() {
   const { dark, toggle } = useThemeStore();
   const { shown } = usePermissionStore();
+  const { lastPrompt, setLastPrompt } = useCheckInStore();
   const location = useLocation();
   const navigate = useNavigate();
+  const [showCheckIn, setShowCheckIn] = React.useState(false);
 
   React.useEffect(() => {
     if (
@@ -27,8 +30,38 @@ function InnerApp() {
     }
   }, [shown, location.pathname, navigate]);
 
+  React.useEffect(() => {
+    const now = Date.now();
+    if (
+      location.pathname !== '/mood' &&
+      location.pathname !== '/permissions' &&
+      now - lastPrompt >= 24 * 60 * 60 * 1000
+    ) {
+      setShowCheckIn(true);
+    }
+  }, [lastPrompt, location.pathname]);
+
+  const handleCheckIn = () => {
+    setLastPrompt(Date.now());
+    setShowCheckIn(false);
+    navigate('/mood');
+  };
+
   return (
     <div className={dark ? 'dark min-h-screen bg-gray-900 text-white' : 'min-h-screen bg-white text-gray-900'}>
+      {showCheckIn && (
+        <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 z-50">
+          <div className="bg-white dark:bg-gray-800 p-4 rounded shadow">
+            <p className="mb-4">It's time for your daily check-in.</p>
+            <button
+              onClick={handleCheckIn}
+              className="px-4 py-2 bg-primary text-white rounded"
+            >
+              Go to Check-In
+            </button>
+          </div>
+        </div>
+      )}
       <button onClick={toggle} className="m-4 p-2 border rounded">
         Toggle Theme
       </button>

--- a/src/components/PermissionsPrompt.tsx
+++ b/src/components/PermissionsPrompt.tsx
@@ -1,9 +1,11 @@
 import { useState } from 'react';
+import { useCheckInStore } from '../contexts/useCheckInStore';
 import { useNavigate } from 'react-router-dom';
 import { usePermissionStore } from '../contexts/usePermissionStore';
 
 export default function PermissionsPrompt() {
   const { setShown } = usePermissionStore();
+  const { setLastPrompt } = useCheckInStore();
   const navigate = useNavigate();
   const [requesting, setRequesting] = useState(false);
 
@@ -22,10 +24,12 @@ export default function PermissionsPrompt() {
       navigator.geolocation.getCurrentPosition(
         () => {
           setShown(true);
+          setLastPrompt(Date.now());
           navigate('/home');
         },
         () => {
           setShown(true);
+          setLastPrompt(Date.now());
           navigate('/home');
         }
       );

--- a/src/contexts/useCheckInStore.ts
+++ b/src/contexts/useCheckInStore.ts
@@ -1,0 +1,19 @@
+import { create } from 'zustand';
+
+interface CheckInState {
+  lastPrompt: number;
+  setLastPrompt: (val: number) => void;
+}
+
+const initialTimestamp = parseInt(
+  localStorage.getItem('lastCheckInPrompt') || '0',
+  10
+);
+
+export const useCheckInStore = create<CheckInState>((set) => ({
+  lastPrompt: initialTimestamp,
+  setLastPrompt: (val) => {
+    localStorage.setItem('lastCheckInPrompt', String(val));
+    set({ lastPrompt: val });
+  },
+}));

--- a/src/pages/MoodEntry.tsx
+++ b/src/pages/MoodEntry.tsx
@@ -1,13 +1,19 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
+import { useCheckInStore } from '../contexts/useCheckInStore';
 
 const moodEmojis = ['\uD83D\uDE22', '\uD83D\uDE41', '\uD83D\uDE10', '\uD83D\uDE42', '\uD83D\uDE04'];
 
 export default function MoodEntry() {
+  const { setLastPrompt } = useCheckInStore();
   const [mood, setMood] = useState(3);
   const [energy, setEnergy] = useState(5);
   const [sleep, setSleep] = useState(5);
   const [light, setLight] = useState(5);
   const [notes, setNotes] = useState('');
+
+  useEffect(() => {
+    setLastPrompt(Date.now());
+  }, [setLastPrompt]);
 
   return (
     <div className="p-4 space-y-6">


### PR DESCRIPTION
## Summary
- store last check-in timestamp in `useCheckInStore`
- show a modal reminder in `App` when 24h passed
- update permission prompt to start the timer
- update mood entry page to refresh the timer when opened

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6850945f4ed0832fa9f59f8c8ff2f5dd