### PR TITLE
Add calendar screen with mood tracking

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -40,6 +40,13 @@ export default function TabLayout() {
           tabBarIcon: ({ color }) => <IconSymbol size={28} name="paperplane.fill" color={color} />,
         }}
       />
+      <Tabs.Screen
+        name="calendar"
+        options={{
+          title: 'Calendar',
+          tabBarIcon: ({ color }) => <IconSymbol size={28} name="calendar" color={color} />,
+        }}
+      />
     </Tabs>
   );
 }

--- a/app/(tabs)/calendar.tsx
+++ b/app/(tabs)/calendar.tsx
@@ -1,0 +1,29 @@
+import { StyleSheet } from 'react-native';
+import { Calendar } from 'react-native-calendars';
+import { useMemo } from 'react';
+
+import { ThemedView } from '@/components/ThemedView';
+import { moodEntries, moodColors } from '@/constants/moods';
+
+export default function CalendarScreen() {
+  const markedDates = useMemo(() => {
+    const marks: Record<string, { marked: boolean; dotColor: string }> = {};
+    moodEntries.forEach((entry) => {
+      marks[entry.date] = { marked: true, dotColor: moodColors[entry.level] };
+    });
+    return marks;
+  }, []);
+
+  return (
+    <ThemedView style={styles.container}>
+      <Calendar markedDates={markedDates} />
+    </ThemedView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    paddingTop: 8,
+  },
+});

--- a/constants/moods.ts
+++ b/constants/moods.ts
@@ -1,0 +1,21 @@
+export type MoodEntry = {
+  date: string; // YYYY-MM-DD
+  level: 1 | 2 | 3 | 4 | 5;
+  notes: string;
+};
+
+export const moodColors: Record<MoodEntry['level'], string> = {
+  1: '#d84c4c',
+  2: '#e3853b',
+  3: '#e3c93b',
+  4: '#64b85e',
+  5: '#3a9e82',
+};
+
+export const moodEntries: MoodEntry[] = [
+  { date: '2024-06-02', level: 4, notes: 'Good day' },
+  { date: '2024-06-05', level: 2, notes: 'Felt tired' },
+  { date: '2024-06-10', level: 5, notes: 'Excellent mood' },
+  { date: '2024-06-15', level: 3, notes: 'Average day' },
+  { date: '2024-06-20', level: 1, notes: 'Pretty bad' },
+];

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "react": "19.0.0",
         "react-dom": "19.0.0",
         "react-native": "0.79.3",
+        "react-native-calendars": "^1.1312.1",
         "react-native-gesture-handler": "~2.24.0",
         "react-native-reanimated": "~3.17.4",
         "react-native-safe-area-context": "5.4.0",
@@ -8557,6 +8558,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
+    },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
@@ -9181,6 +9188,16 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/ms": {
@@ -10015,7 +10032,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
@@ -10027,7 +10043,6 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/punycode": {
@@ -10263,6 +10278,38 @@
         }
       }
     },
+    "node_modules/react-native-calendars": {
+      "version": "1.1312.1",
+      "resolved": "https://registry.npmjs.org/react-native-calendars/-/react-native-calendars-1.1312.1.tgz",
+      "integrity": "sha512-295577LyDmLF53wURndNFly6SFQRpKR4d+fzGiIUs1FzdT1JK7uydtCUqm4++eKDuwhsz2mXJkszmTi6etsTdw==",
+      "license": "MIT",
+      "dependencies": {
+        "hoist-non-react-statics": "^3.3.1",
+        "lodash": "^4.17.15",
+        "memoize-one": "^5.2.1",
+        "prop-types": "^15.5.10",
+        "react-native-safe-area-context": "4.5.0",
+        "react-native-swipe-gestures": "^1.0.5",
+        "recyclerlistview": "^4.0.0",
+        "xdate": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "moment": "^2.29.4"
+      }
+    },
+    "node_modules/react-native-calendars/node_modules/react-native-safe-area-context": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-4.5.0.tgz",
+      "integrity": "sha512-0WORnk9SkREGUg2V7jHZbuN5x4vcxj/1B0QOcXJjdYWrzZHgLcUzYWWIUecUPJh747Mwjt/42RZDOaFn3L8kPQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
     "node_modules/react-native-edge-to-edge": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/react-native-edge-to-edge/-/react-native-edge-to-edge-1.6.0.tgz",
@@ -10347,6 +10394,12 @@
         "react": "*",
         "react-native": "*"
       }
+    },
+    "node_modules/react-native-swipe-gestures": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/react-native-swipe-gestures/-/react-native-swipe-gestures-1.0.5.tgz",
+      "integrity": "sha512-Ns7Bn9H/Tyw278+5SQx9oAblDZ7JixyzeOczcBK8dipQk2pD7Djkcfnf1nB/8RErAmMLL9iXgW0QHqiII8AhKw==",
+      "license": "MIT"
     },
     "node_modules/react-native-web": {
       "version": "0.20.0",
@@ -10481,6 +10534,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/recyclerlistview": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/recyclerlistview/-/recyclerlistview-4.2.3.tgz",
+      "integrity": "sha512-STR/wj/FyT8EMsBzzhZ1l2goYirMkIgfV3gYEPxI3Kf3lOnu6f7Dryhyw7/IkQrgX5xtTcDrZMqytvteH9rL3g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.debounce": "4.0.8",
+        "prop-types": "15.8.1",
+        "ts-object-utils": "0.0.5"
+      },
+      "peerDependencies": {
+        "react": ">= 15.2.1",
+        "react-native": ">= 0.30.0"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -12032,6 +12100,12 @@
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "license": "Apache-2.0"
     },
+    "node_modules/ts-object-utils": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/ts-object-utils/-/ts-object-utils-0.0.5.tgz",
+      "integrity": "sha512-iV0GvHqOmilbIKJsfyfJY9/dNHCs969z3so90dQWsO1eMMozvTpnB1MEaUbb3FYtZTGjv5sIy/xmslEz0Rg2TA==",
+      "license": "ISC"
+    },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
@@ -12791,6 +12865,12 @@
       "engines": {
         "node": ">=10.0.0"
       }
+    },
+    "node_modules/xdate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/xdate/-/xdate-0.8.3.tgz",
+      "integrity": "sha512-1NhJWPJwN+VjbkACT9XHbQK4o6exeSVtS2CxhMPwUE7xQakoEFTlwra9YcqV/uHQVyeEUYoYC46VGDJ+etnIiw==",
+      "license": "(MIT OR GPL-2.0)"
     },
     "node_modules/xml2js": {
       "version": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "react-native-safe-area-context": "5.4.0",
     "react-native-screens": "~4.11.1",
     "react-native-web": "~0.20.0",
-    "react-native-webview": "13.13.5"
+    "react-native-webview": "13.13.5",
+    "react-native-calendars": "^1.1312.1"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",


### PR DESCRIPTION
## Summary
- install `react-native-calendars`
- add mood entry data in `constants/moods.ts`
- create month view calendar screen
- register Calendar screen in tab layout

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68518690c41c832f8f10768c89dfc728