### PR TITLE
Add async storage for mood entries

### DIFF
--- a/app/(tabs)/calendar.tsx
+++ b/app/(tabs)/calendar.tsx
@@ -1,27 +1,46 @@
 import { StyleSheet } from 'react-native';
 import { Calendar, type DateData } from 'react-native-calendars';
-import { useMemo, useState, useCallback } from 'react';
+import { useMemo, useState, useCallback, useEffect } from 'react';
 
 import { ThemedView } from '@/components/ThemedView';
 import DayDetailModal from '@/components/DayDetailModal';
-import { moodEntries, moodColors, type MoodEntry } from '@/constants/moods';
+import { moodColors, moodEntries as sampleEntries, type MoodEntry } from '@/constants/moods';
+import { loadMoodEntries, saveMoodEntries } from '@/hooks/useMoodStorage';
 
 export default function CalendarScreen() {
   const [selectedEntry, setSelectedEntry] = useState<MoodEntry | null>(null);
+  const [entries, setEntries] = useState<MoodEntry[]>([]);
+
+  useEffect(() => {
+    async function init() {
+      const stored = await loadMoodEntries();
+      if (stored.length === 0) {
+        await saveMoodEntries(sampleEntries);
+        setEntries(sampleEntries);
+      } else {
+        setEntries(stored);
+      }
+    }
+    init();
+  }, []);
+
   const markedDates = useMemo(() => {
     const marks: Record<string, { marked: boolean; dotColor: string }> = {};
-    moodEntries.forEach((entry) => {
+    entries.forEach((entry) => {
       marks[entry.date] = { marked: true, dotColor: moodColors[entry.level] };
     });
     return marks;
-  }, []);
+  }, [entries]);
 
-  const handleDayPress = useCallback((day: DateData) => {
-    const entry = moodEntries.find((e) => e.date === day.dateString);
-    if (entry) {
-      setSelectedEntry(entry);
-    }
-  }, []);
+  const handleDayPress = useCallback(
+    (day: DateData) => {
+      const entry = entries.find((e) => e.date === day.dateString);
+      if (entry) {
+        setSelectedEntry(entry);
+      }
+    },
+    [entries]
+  );
 
   return (
     <ThemedView style={styles.container}>

--- a/components/DayDetailModal.tsx
+++ b/components/DayDetailModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useCallback } from 'react';
 import { Modal, Pressable, StyleSheet, View } from 'react-native';
 import Animated, {
   runOnJS,
@@ -11,6 +11,7 @@ import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import { ThemedText } from './ThemedText';
 import { useThemeColor } from '@/hooks/useThemeColor';
 import type { MoodEntry } from '@/constants/moods';
+import { saveMoodEntry } from '@/hooks/useMoodStorage';
 
 export type DayDetailModalProps = {
   visible: boolean;
@@ -21,6 +22,13 @@ export type DayDetailModalProps = {
 export default function DayDetailModal({ visible, entry, onDismiss }: DayDetailModalProps) {
   const backgroundColor = useThemeColor({}, 'background');
   const translateY = useSharedValue(0);
+
+  const handleDismiss = useCallback(() => {
+    if (entry) {
+      saveMoodEntry(entry);
+    }
+    onDismiss();
+  }, [entry, onDismiss]);
 
   useEffect(() => {
     if (visible) {
@@ -36,7 +44,7 @@ export default function DayDetailModal({ visible, entry, onDismiss }: DayDetailM
     })
     .onEnd((e) => {
       if (e.translationY > 100) {
-        translateY.value = withTiming(400, { duration: 150 }, () => runOnJS(onDismiss)());
+        translateY.value = withTiming(400, { duration: 150 }, () => runOnJS(handleDismiss)());
       } else {
         translateY.value = withTiming(0);
       }
@@ -51,11 +59,11 @@ export default function DayDetailModal({ visible, entry, onDismiss }: DayDetailM
       visible={visible}
       transparent
       animationType="slide"
-      onRequestClose={onDismiss}>
+      onRequestClose={handleDismiss}>
       <View style={styles.overlay}>
         <GestureDetector gesture={gesture}>
           <Animated.View style={[styles.container, { backgroundColor }, animatedStyle]}>
-            <Pressable onPress={onDismiss} style={styles.dismiss} hitSlop={8}>
+            <Pressable onPress={handleDismiss} style={styles.dismiss} hitSlop={8}>
               <ThemedText type="link">Dismiss</ThemedText>
             </Pressable>
             {entry && (

--- a/hooks/useMoodStorage.ts
+++ b/hooks/useMoodStorage.ts
@@ -1,0 +1,48 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import type { MoodEntry } from '@/constants/moods';
+
+const STORAGE_KEY = 'moodEntries';
+
+export async function loadMoodEntries(): Promise<MoodEntry[]> {
+  try {
+    const json = await AsyncStorage.getItem(STORAGE_KEY);
+    if (!json) {
+      return [];
+    }
+    return JSON.parse(json) as MoodEntry[];
+  } catch (e) {
+    console.warn('Failed to load mood entries', e);
+    return [];
+  }
+}
+
+export async function saveMoodEntry(entry: MoodEntry): Promise<void> {
+  const entries = await loadMoodEntries();
+  const index = entries.findIndex((e) => e.date === entry.date);
+  if (index >= 0) {
+    entries[index] = entry;
+  } else {
+    entries.push(entry);
+  }
+  try {
+    await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(entries));
+  } catch (e) {
+    console.warn('Failed to save mood entry', e);
+  }
+}
+
+export async function saveMoodEntries(entries: MoodEntry[]): Promise<void> {
+  try {
+    await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(entries));
+  } catch (e) {
+    console.warn('Failed to save mood entries', e);
+  }
+}
+
+export async function clearMoodEntries() {
+  try {
+    await AsyncStorage.removeItem(STORAGE_KEY);
+  } catch (e) {
+    console.warn('Failed to clear mood entries', e);
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@expo/vector-icons": "^14.1.0",
+        "@react-native-async-storage/async-storage": "^1.21.0",
         "@react-navigation/bottom-tabs": "^7.3.10",
         "@react-navigation/elements": "^2.3.8",
         "@react-navigation/native": "^7.1.6",
@@ -2814,6 +2815,18 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@react-native-async-storage/async-storage": {
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-1.24.0.tgz",
+      "integrity": "sha512-W4/vbwUOYOjco0x3toB8QCr7EjIP6nE9G7o8PMguvvjYT5Awg09lyV4enACRx4s++PPulBiBSjL0KTFx2u0Z/g==",
+      "license": "MIT",
+      "dependencies": {
+        "merge-options": "^3.0.4"
+      },
+      "peerDependencies": {
+        "react-native": "^0.0.0-0 || >=0.60 <1.0"
       }
     },
     "node_modules/@react-native/assets-registry": {
@@ -7726,6 +7739,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -8717,6 +8739,18 @@
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
       "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
       "license": "MIT"
+    },
+    "node_modules/merge-options": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
+      "integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "react-native-screens": "~4.11.1",
     "react-native-web": "~0.20.0",
     "react-native-webview": "13.13.5",
-    "react-native-calendars": "^1.1312.1"
+    "react-native-calendars": "^1.1312.1",
+    "@react-native-async-storage/async-storage": "^1.21.0"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",


### PR DESCRIPTION
## Summary
- use AsyncStorage for persistent mood data
- add helper functions in `useMoodStorage`
- load data in calendar screen
- save entries when closing modal
- include async-storage dependency

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68518ae258fc832faecb29b89ff9a914