### PR TITLE
Add calendar page with mood history

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,19 @@ export default tseslint.config({
   rules: {
     // other rules...
     // Enable its recommended typescript rules
-    ...reactX.configs['recommended-typescript'].rules,
-    ...reactDom.configs.recommended.rules,
+  ...reactX.configs['recommended-typescript'].rules,
+  ...reactDom.configs.recommended.rules,
   },
 })
 ```
+
+## Calendar and date utilities
+
+The calendar page uses [`date-fns`](https://date-fns.org/) for working with
+dates. Install dependencies, including this library, with:
+
+```bash
+npm install
+```
+
+See `src/pages/Calendar.tsx` for usage examples.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "sad",
       "version": "0.0.0",
       "dependencies": {
+        "date-fns": "^4.1.0",
         "framer-motion": "^12.18.1",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
@@ -2299,6 +2300,16 @@
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.1",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router-dom": "^7.6.2",
-    "zustand": "^5.0.5"
+    "zustand": "^5.0.5",
+    "date-fns": "^4.1.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import Home from './pages/Home';
 import About from './pages/About';
 import Customize from './pages/Customize';
 import MoodEntry from './pages/MoodEntry';
+import Calendar from './pages/Calendar';
 import WelcomeCarousel from './components/WelcomeCarousel';
 import { useThemeStore } from './contexts/useThemeStore';
 import PermissionsPrompt from './components/PermissionsPrompt';
@@ -73,6 +74,7 @@ function InnerApp() {
         <Route path="/about" element={<About />} />
         <Route path="/customize" element={<Customize />} />
         <Route path="/mood" element={<MoodEntry />} />
+        <Route path="/calendar" element={<Calendar />} />
       </Routes>
     </div>
   );

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -7,6 +7,7 @@ export default function NavBar() {
       <Link to="/about" className="text-blue-600 dark:text-blue-400">About</Link>
       <Link to="/customize" className="text-blue-600 dark:text-blue-400">Customize</Link>
       <Link to="/mood" className="text-blue-600 dark:text-blue-400">Mood</Link>
+      <Link to="/calendar" className="text-blue-600 dark:text-blue-400">Calendar</Link>
     </nav>
   );
 }

--- a/src/pages/Calendar.tsx
+++ b/src/pages/Calendar.tsx
@@ -1,0 +1,114 @@
+import React from 'react';
+import {
+  addMonths,
+  format,
+  startOfMonth,
+  endOfMonth,
+  startOfWeek,
+  endOfWeek,
+  addDays,
+  isSameMonth,
+} from 'date-fns';
+import { useMoodStore, MoodEntry } from '../contexts/useMoodStore';
+
+interface DayDetailModalProps {
+  date: Date;
+  entry?: MoodEntry;
+  onClose: () => void;
+}
+
+function DayDetailModal({ date, entry, onClose }: DayDetailModalProps) {
+  return (
+    <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 z-50">
+      <div className="bg-white dark:bg-gray-800 p-4 rounded shadow max-w-sm w-full">
+        <h2 className="text-lg font-bold mb-2">{format(date, 'PPP')}</h2>
+        {entry ? (
+          <div className="space-y-1">
+            <p>Mood: {entry.mood}</p>
+            <p>Energy: {entry.energy}</p>
+            <p>Sleep: {entry.sleep}</p>
+            <p>Light: {entry.light}</p>
+            {entry.notes && <p>Notes: {entry.notes}</p>}
+          </div>
+        ) : (
+          <p>No entry for this day.</p>
+        )}
+        <button
+          onClick={onClose}
+          className="mt-4 px-4 py-2 bg-primary text-white rounded"
+        >
+          Close
+        </button>
+      </div>
+    </div>
+  );
+}
+
+const moodColors: Record<number, string> = {
+  1: 'bg-red-500',
+  2: 'bg-orange-500',
+  3: 'bg-yellow-400',
+  4: 'bg-green-500',
+  5: 'bg-blue-500',
+};
+
+export default function Calendar() {
+  const [currentMonth, setCurrentMonth] = React.useState<Date>(startOfMonth(new Date()));
+  const entries = useMoodStore((state) => state.entries);
+  const entryMap = React.useMemo(() => {
+    const map: Record<string, MoodEntry> = {};
+    for (const e of entries) {
+      const key = format(e.timestamp, 'yyyy-MM-dd');
+      map[key] = e;
+    }
+    return map;
+  }, [entries]);
+
+  const [selected, setSelected] = React.useState<Date | null>(null);
+
+  const start = startOfWeek(startOfMonth(currentMonth));
+  const end = endOfWeek(endOfMonth(currentMonth));
+  const days: Date[] = [];
+  for (let d = start; d <= end; d = addDays(d, 1)) {
+    days.push(d);
+  }
+
+  return (
+    <div className="p-4">
+      <div className="flex items-center justify-between mb-4">
+        <button onClick={() => setCurrentMonth(addMonths(currentMonth, -1))} className="px-2">Prev</button>
+        <h2 className="text-xl font-bold">{format(currentMonth, 'MMMM yyyy')}</h2>
+        <button onClick={() => setCurrentMonth(addMonths(currentMonth, 1))} className="px-2">Next</button>
+      </div>
+      <div className="grid grid-cols-7 gap-2 text-center">
+        {['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'].map((d) => (
+          <div key={d} className="font-semibold">{d}</div>
+        ))}
+        {days.map((day) => {
+          const key = format(day, 'yyyy-MM-dd');
+          const entry = entryMap[key];
+          const inMonth = isSameMonth(day, currentMonth);
+          return (
+            <button
+              key={key}
+              onClick={() => setSelected(day)}
+              className={`h-16 border rounded flex flex-col items-center justify-center ${!inMonth ? 'text-gray-400' : ''}`}
+            >
+              <span>{format(day, 'd')}</span>
+              {entry && (
+                <span className={`mt-1 w-2 h-2 rounded-full ${moodColors[entry.mood]}`} />
+              )}
+            </button>
+          );
+        })}
+      </div>
+      {selected && (
+        <DayDetailModal
+          date={selected}
+          entry={entryMap[format(selected, 'yyyy-MM-dd')]}
+          onClose={() => setSelected(null)}
+        />
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add Calendar page with month view and mood dots
- support showing mood entry details in a modal
- add date-fns dependency and document usage
- link Calendar in NavBar and route in App

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685193c3686c832faa5946177268199a