### PR TITLE
Fix Calendar imports

### DIFF
--- a/src/pages/Calendar.tsx
+++ b/src/pages/Calendar.tsx
@@ -9,7 +9,8 @@ import {
   addDays,
   isSameMonth,
 } from 'date-fns';
-import { useMoodStore, MoodEntry } from '../contexts/useMoodStore';
+import { useMoodStore } from '../contexts/useMoodStore';
+import type { MoodEntry } from '../contexts/useMoodStore';
 
 interface DayDetailModalProps {
   date: Date;


### PR DESCRIPTION
## Summary
- clean up `MoodEntry` import so it's type-only

## Testing
- `npm run lint`
- `curl -I http://localhost:5174/calendar`

------
https://chatgpt.com/codex/tasks/task_e_6851965d4870832f92b57b01c0582d45