### PR TITLE
Add therapy scheduler

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import About from './pages/About';
 import Customize from './pages/Customize';
 import MoodEntry from './pages/MoodEntry';
 import Calendar from './pages/Calendar';
+import TherapyScheduler from './pages/TherapyScheduler';
 import WelcomeCarousel from './components/WelcomeCarousel';
 import { useThemeStore } from './contexts/useThemeStore';
 import PermissionsPrompt from './components/PermissionsPrompt';
@@ -75,6 +76,7 @@ function InnerApp() {
         <Route path="/customize" element={<Customize />} />
         <Route path="/mood" element={<MoodEntry />} />
         <Route path="/calendar" element={<Calendar />} />
+        <Route path="/scheduler" element={<TherapyScheduler />} />
       </Routes>
     </div>
   );

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -8,6 +8,7 @@ export default function NavBar() {
       <Link to="/customize" className="text-blue-600 dark:text-blue-400">Customize</Link>
       <Link to="/mood" className="text-blue-600 dark:text-blue-400">Mood</Link>
       <Link to="/calendar" className="text-blue-600 dark:text-blue-400">Calendar</Link>
+      <Link to="/scheduler" className="text-blue-600 dark:text-blue-400">Scheduler</Link>
     </nav>
   );
 }

--- a/src/contexts/useSchedulerStore.ts
+++ b/src/contexts/useSchedulerStore.ts
@@ -1,0 +1,24 @@
+import { create } from 'zustand';
+
+interface SchedulerState {
+  times: string[];
+  addTime: (time: string) => void;
+  removeTime: (time: string) => void;
+}
+
+const stored = localStorage.getItem('scheduledTimes');
+const initialTimes: string[] = stored ? JSON.parse(stored) : [];
+
+export const useSchedulerStore = create<SchedulerState>((set, get) => ({
+  times: initialTimes,
+  addTime: (time) => {
+    const updated = Array.from(new Set([...get().times, time])).sort();
+    localStorage.setItem('scheduledTimes', JSON.stringify(updated));
+    set({ times: updated });
+  },
+  removeTime: (time) => {
+    const updated = get().times.filter((t) => t !== time);
+    localStorage.setItem('scheduledTimes', JSON.stringify(updated));
+    set({ times: updated });
+  },
+}));

--- a/src/pages/TherapyScheduler.tsx
+++ b/src/pages/TherapyScheduler.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import { useSchedulerStore } from '../contexts/useSchedulerStore';
+
+export default function TherapyScheduler() {
+  const { times, addTime, removeTime } = useSchedulerStore();
+  const [newTime, setNewTime] = React.useState('12:00');
+
+  React.useEffect(() => {
+    if (typeof window === 'undefined' || !('Notification' in window)) {
+      return;
+    }
+    if (Notification.permission === 'default') {
+      void Notification.requestPermission();
+    }
+
+    const ids: number[] = [];
+
+    const schedule = (time: string) => {
+      const [h, m] = time.split(':').map(Number);
+      const now = new Date();
+      const next = new Date();
+      next.setHours(h, m, 0, 0);
+      if (next.getTime() <= now.getTime()) {
+        next.setDate(next.getDate() + 1);
+      }
+      const delay = next.getTime() - now.getTime();
+
+      const trigger = () => {
+        if (Notification.permission === 'granted') {
+          new Notification('Therapy Reminder', {
+            body: 'It is time for your scheduled therapy activity.',
+          });
+        }
+        const id2 = window.setTimeout(trigger, 24 * 60 * 60 * 1000);
+        ids.push(id2);
+      };
+
+      const id = window.setTimeout(trigger, delay);
+      ids.push(id);
+    };
+
+    times.forEach(schedule);
+
+    return () => {
+      ids.forEach((id) => clearTimeout(id));
+    };
+  }, [times]);
+
+  const handleAdd = () => {
+    if (newTime && !times.includes(newTime)) {
+      addTime(newTime);
+    }
+  };
+
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl font-bold mb-4">Therapy Scheduler</h1>
+      <div className="flex items-center gap-2 mb-4">
+        <input
+          type="time"
+          value={newTime}
+          onChange={(e) => setNewTime(e.target.value)}
+          className="border p-2 rounded text-gray-900 dark:text-white"
+        />
+        <button onClick={handleAdd} className="px-4 py-2 bg-primary text-white rounded">
+          Add
+        </button>
+      </div>
+      <ul className="space-y-2">
+        {times.map((time) => (
+          <li key={time} className="flex items-center gap-2">
+            <span className="flex-1">{time}</span>
+            <button
+              onClick={() => removeTime(time)}
+              className="px-2 py-1 bg-red-500 text-white rounded"
+            >
+              Remove
+            </button>
+          </li>
+        ))}
+        {times.length === 0 && <li>No times scheduled.</li>}
+      </ul>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add scheduler store to manage therapy reminders
- create TherapyScheduler page with time picker
- register new route and navbar link
- set daily notifications for selected times

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6851993176d8832f8730a729c1a91883