### PR TITLE
Add countdown timer page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import Customize from './pages/Customize';
 import MoodEntry from './pages/MoodEntry';
 import Calendar from './pages/Calendar';
 import TherapyScheduler from './pages/TherapyScheduler';
+import Timer from './pages/Timer';
 import WelcomeCarousel from './components/WelcomeCarousel';
 import { useThemeStore } from './contexts/useThemeStore';
 import PermissionsPrompt from './components/PermissionsPrompt';
@@ -77,6 +78,7 @@ function InnerApp() {
         <Route path="/mood" element={<MoodEntry />} />
         <Route path="/calendar" element={<Calendar />} />
         <Route path="/scheduler" element={<TherapyScheduler />} />
+        <Route path="/timer" element={<Timer />} />
       </Routes>
     </div>
   );

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -9,6 +9,7 @@ export default function NavBar() {
       <Link to="/mood" className="text-blue-600 dark:text-blue-400">Mood</Link>
       <Link to="/calendar" className="text-blue-600 dark:text-blue-400">Calendar</Link>
       <Link to="/scheduler" className="text-blue-600 dark:text-blue-400">Scheduler</Link>
+      <Link to="/timer" className="text-blue-600 dark:text-blue-400">Timer</Link>
     </nav>
   );
 }

--- a/src/pages/Timer.tsx
+++ b/src/pages/Timer.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+
+const DURATION = 60; // seconds
+
+export default function Timer() {
+  const [timeLeft, setTimeLeft] = React.useState(DURATION);
+  const [isActive, setIsActive] = React.useState(false);
+
+  React.useEffect(() => {
+    if (!isActive) return;
+    if (timeLeft <= 0) {
+      setIsActive(false);
+      return;
+    }
+    const id = setInterval(() => {
+      setTimeLeft((t) => (t > 0 ? t - 1 : 0));
+    }, 1000);
+    return () => clearInterval(id);
+  }, [isActive, timeLeft]);
+
+  const toggle = () => setIsActive((a) => !a);
+  const reset = () => {
+    setIsActive(false);
+    setTimeLeft(DURATION);
+  };
+
+  const progress = (timeLeft / DURATION) * 100;
+
+  return (
+    <div className="p-4 flex flex-col items-center gap-4">
+      <div className="w-full bg-gray-200 dark:bg-gray-700 h-2 rounded">
+        <motion.div
+          animate={{ width: `${progress}%` }}
+          className="h-2 bg-primary rounded"
+        />
+      </div>
+      <motion.div
+        key={timeLeft}
+        initial={{ scale: 0.8, opacity: 0 }}
+        animate={{ scale: 1, opacity: 1 }}
+        className="text-5xl font-mono"
+      >
+        {timeLeft > 0 ? timeLeft : "Time's up!"}
+      </motion.div>
+      <div className="flex gap-2">
+        <button
+          onClick={toggle}
+          className="px-4 py-2 bg-primary text-white rounded"
+        >
+          {isActive ? 'Pause' : 'Start'}
+        </button>
+        <button onClick={reset} className="px-4 py-2 border rounded">
+          Reset
+        </button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a new timer page with a start/pauseable countdown using framer-motion for subtle animations
- hook the timer into routing
- expose navigation link in the navbar

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68519a2a95a8832f809fbf1345305594