### PR TITLE
Add mood streak tracker with UI

### DIFF
--- a/src/components/StreakCounter.tsx
+++ b/src/components/StreakCounter.tsx
@@ -1,0 +1,19 @@
+import { useMoodStore } from '../contexts/useMoodStore';
+
+export default function StreakCounter() {
+  const getStreak = useMoodStore((state) => state.getStreak);
+  const streak = getStreak();
+
+  let reward = '';
+  if (streak >= 30) reward = '🏆';
+  else if (streak >= 7) reward = '🔥';
+
+  return (
+    <div className="mt-4 p-4 border rounded">
+      <h2 className="text-lg font-bold">Current Streak</h2>
+      <p className="text-2xl">
+        {streak} day{streak === 1 ? '' : 's'} {reward}
+      </p>
+    </div>
+  );
+}

--- a/src/contexts/useMoodStore.ts
+++ b/src/contexts/useMoodStore.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+import { format, subDays, startOfDay } from 'date-fns';
 
 export interface MoodEntry {
   timestamp: number;
@@ -14,6 +15,7 @@ interface MoodState {
   entries: MoodEntry[];
   addEntry: (data: Omit<MoodEntry, 'timestamp' | 'coords'>) => Promise<void>;
   getEntries: () => MoodEntry[];
+  getStreak: () => number;
 }
 
 const stored = localStorage.getItem('moodEntries');
@@ -46,4 +48,21 @@ export const useMoodStore = create<MoodState>((set, get) => ({
     set({ entries: updated });
   },
   getEntries: () => get().entries,
+  getStreak: () => {
+    const entryDates = new Set(
+      get()
+        .entries
+        .map((e) => format(e.timestamp, 'yyyy-MM-dd')),
+    );
+
+    let streak = 0;
+    let day = startOfDay(new Date());
+
+    while (entryDates.has(format(day, 'yyyy-MM-dd'))) {
+      streak += 1;
+      day = subDays(day, 1);
+    }
+
+    return streak;
+  },
 }));

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,10 +1,12 @@
 import { motion } from 'framer-motion';
+import StreakCounter from '../components/StreakCounter';
 
 export default function Home() {
   return (
     <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="p-4">
       <h1 className="text-2xl font-bold">Home Page</h1>
       <p className="mt-2">Welcome to the app.</p>
+      <StreakCounter />
     </motion.div>
   );
 }


### PR DESCRIPTION
## Summary
- track consecutive check-in days with `getStreak` in the mood store
- display a new `StreakCounter` component with milestone rewards
- show the streak counter on the home page

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68519aeb3be0832fb24bc7b18e3865d6