### PR TITLE
Add season theme helper and apply backgrounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,11 @@ without building will omit all CSS.
 
 Customization settings are managed with a zustand store and persisted to
 `localStorage`. On the **Customize** page you can toggle dark mode, select a
-season and set how frequently notifications should appear. These choices are
-loaded when the app starts so your preferred theme and settings remain across
-visits.
+season and set how frequently notifications should appear. Each season maps to
+a background gradient and optional illustration loaded from the `public/`
+folder. Selecting a different season instantly changes the look of the app.
+These choices are loaded when the app starts so your preferred theme and
+settings remain across visits.
 
 ## Expanding the ESLint configuration
 

--- a/public/autumn.svg
+++ b/public/autumn.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect width="100" height="100" fill="#fb923c" />
+</svg>

--- a/public/spring.svg
+++ b/public/spring.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect width="100" height="100" fill="#86efac" />
+</svg>

--- a/public/summer.svg
+++ b/public/summer.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect width="100" height="100" fill="#fde047" />
+</svg>

--- a/public/winter.svg
+++ b/public/winter.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect width="100" height="100" fill="#93c5fd" />
+</svg>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,13 +10,15 @@ import TherapyScheduler from './pages/TherapyScheduler';
 import Timer from './pages/Timer';
 import WelcomeCarousel from './components/WelcomeCarousel';
 import { useThemeStore } from './contexts/useThemeStore';
+import { getSeasonColors } from './utils/getSeasonColors';
 import PermissionsPrompt from './components/PermissionsPrompt';
 import { usePermissionStore } from './contexts/usePermissionStore';
 import { useCheckInStore } from './contexts/useCheckInStore';
 import './index.css';
 
 function InnerApp() {
-  const { dark, toggle } = useThemeStore();
+  const { dark, toggle, season } = useThemeStore();
+  const colors = getSeasonColors(season);
   const { shown } = usePermissionStore();
   const { lastPrompt, setLastPrompt } = useCheckInStore();
   const location = useLocation();
@@ -51,7 +53,12 @@ function InnerApp() {
   };
 
   return (
-    <div className={dark ? 'dark min-h-screen bg-gray-900 text-white' : 'min-h-screen bg-white text-gray-900'}>
+    <div
+      className={`min-h-screen ${
+        dark ? 'dark bg-gray-900 text-white' : `${colors.bg} text-gray-900`
+      }`}
+      style={{ backgroundImage: `url(${colors.image})`, backgroundSize: 'cover' }}
+    >
       {showCheckIn && (
         <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 z-50">
           <div className="bg-white dark:bg-gray-800 p-4 rounded shadow">

--- a/src/contexts/useMoodStore.test.ts
+++ b/src/contexts/useMoodStore.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { describe, it, expect, beforeEach } from 'vitest'
 import { useMoodStore } from './useMoodStore'
 
 declare global {

--- a/src/utils/getSeasonColors.ts
+++ b/src/utils/getSeasonColors.ts
@@ -1,0 +1,29 @@
+export interface SeasonColors {
+  /** Background classes to apply for the season */
+  bg: string
+  /** Optional illustration path placed under public/ */
+  image: string
+}
+
+const MAP: Record<string, SeasonColors> = {
+  Spring: {
+    bg: 'bg-gradient-to-b from-green-100 via-green-200 to-green-300',
+    image: '/spring.svg',
+  },
+  Summer: {
+    bg: 'bg-gradient-to-b from-yellow-100 via-yellow-200 to-yellow-300',
+    image: '/summer.svg',
+  },
+  Autumn: {
+    bg: 'bg-gradient-to-b from-orange-200 via-orange-300 to-yellow-300',
+    image: '/autumn.svg',
+  },
+  Winter: {
+    bg: 'bg-gradient-to-b from-blue-100 via-blue-200 to-blue-300',
+    image: '/winter.svg',
+  },
+}
+
+export function getSeasonColors(season: string): SeasonColors {
+  return MAP[season] ?? MAP.Spring
+}


### PR DESCRIPTION
## Summary
- map seasons to background classes and images
- show the selected season theme in the main layout
- provide simple seasonal illustrations
- explain seasonal background behavior in README

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6851b99d06ec832f80da7de6ebf1311a