### PR TITLE
Add ContentFeed tips feed

### DIFF
--- a/src/components/ContentFeed.tsx
+++ b/src/components/ContentFeed.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+const tips: string[] = [
+  'Take a short walk outside.',
+  'Write down something you\'re grateful for.',
+  'Practice deep breathing for one minute.',
+  'Reach out to a friend or family member.',
+  'Take a moment to stretch.',
+];
+
+export default function ContentFeed() {
+  return (
+    <div className="h-48 overflow-y-auto scroll-smooth space-y-2 p-2 border rounded">
+      {tips.map((tip, index) => (
+        <div
+          key={index}
+          className="p-2 bg-gray-100 dark:bg-gray-700 rounded"
+        >
+          {tip}
+        </div>
+      ))}
+    </div>
+  );
+}
+

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,5 +1,6 @@
 import { motion } from 'framer-motion';
 import StreakCounter from '../components/StreakCounter';
+import ContentFeed from '../components/ContentFeed';
 
 export default function Home() {
   return (
@@ -7,6 +8,10 @@ export default function Home() {
       <h1 className="text-2xl font-bold">Home Page</h1>
       <p className="mt-2">Welcome to the app.</p>
       <StreakCounter />
+      <div className="mt-4">
+        <ContentFeed />
+      </div>
     </motion.div>
   );
 }
+


### PR DESCRIPTION
## Summary
- show tips in a scrolling feed
- display ContentFeed on the home page

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6851bbb0c470832f87ea4b1602b2cce6