### PR TITLE
Improve lint instructions and add dependency check

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ location data will be unavailable.
 
 ## Getting Started
 
-Install dependencies before running any build or lint step:
+Install dependencies before running any build, test or lint step. **Skipping this will cause `npm run lint` to fail.**
 
 ```bash
 npm install
@@ -45,7 +45,7 @@ Create a production build:
 npm run build
 ```
 
-Run the linter after installing dependencies:
+Run the linter once dependencies are installed:
 
 ```bash
 npm run lint

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
+    "prelint": "node scripts/check-deps.cjs",
     "lint": "eslint .",
     "preview": "vite preview",
     "test": "vitest"

--- a/scripts/check-deps.cjs
+++ b/scripts/check-deps.cjs
@@ -1,0 +1,8 @@
+const fs = require('fs');
+const path = require('path');
+
+const nodeModules = path.join(__dirname, '..', 'node_modules');
+if (!fs.existsSync(nodeModules)) {
+  console.error('Dependencies missing. Run "npm install" first.');
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- emphasize running `npm install` before using the linter
- add a `prelint` script that verifies dependencies

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6851bd40d080832fb2ac2971cdbb017c