### PR TITLE
Add analytics page with charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ browser.
 - **Customization** – toggle dark mode, choose a seasonal theme (Spring, Summer,
   Autumn or Winter) and adjust notification frequency.
 - **Streak Counter** – see how many days in a row you've entered your mood.
+- **Analytics** – visualize mood trends and light exposure with interactive charts.
 
 ## Browser requirements
 
@@ -37,6 +38,9 @@ Install dependencies before running any build, test or lint step. **Skipping thi
 ```bash
 npm install
 ```
+
+This also installs the charting libraries `chart.js` and `react-chartjs-2`
+used by the analytics page.
 
 Start the development server:
 
@@ -133,6 +137,12 @@ npm install
 ```
 
 See `src/pages/Calendar.tsx` for usage examples.
+
+## Analytics and charts
+
+Mood trends are visualized using [Chart.js](https://www.chartjs.org/) via the
+`react-chartjs-2` bindings. Both packages are installed with the project
+dependencies and loaded by the `Analytics` page under `src/pages/Analytics.tsx`.
 
 ## License
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,11 @@
       "name": "sad",
       "version": "0.0.0",
       "dependencies": {
+        "chart.js": "^4.5.0",
         "date-fns": "^4.1.0",
         "framer-motion": "^12.18.1",
         "react": "^19.1.0",
+        "react-chartjs-2": "^5.3.0",
         "react-dom": "^19.1.0",
         "react-router-dom": "^7.6.2",
         "zustand": "^5.0.5"
@@ -33,6 +35,9 @@
         "typescript-eslint": "^8.30.1",
         "vite": "^6.3.5",
         "vitest": "^3.2.4"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -1208,6 +1213,12 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "license": "MIT"
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -2421,6 +2432,18 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chart.js": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.0.tgz",
+      "integrity": "sha512-aYeC/jDgSEx8SHWZvANYMioYMZ2KX02W6f6uVfyteuCGcadDLcYVHdfdygsTQkQ4TKn5lghoojAsPj5pu0SnvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
       }
     },
     "node_modules/check-error": {
@@ -4565,6 +4588,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-chartjs-2": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/react-chartjs-2/-/react-chartjs-2-5.3.0.tgz",
+      "integrity": "sha512-UfZZFnDsERI3c3CZGxzvNJd02SHjaSJ8kgW1djn65H1KK8rehwTjyrRKOG3VTMG8wtHZ5rgAO5oTHtHi9GCCmw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "chart.js": "^4.1.1",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/react-dom": {

--- a/package.json
+++ b/package.json
@@ -15,9 +15,11 @@
     "test": "vitest"
   },
   "dependencies": {
+    "chart.js": "^4.5.0",
     "date-fns": "^4.1.0",
     "framer-motion": "^12.18.1",
     "react": "^19.1.0",
+    "react-chartjs-2": "^5.3.0",
     "react-dom": "^19.1.0",
     "react-router-dom": "^7.6.2",
     "zustand": "^5.0.5"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import MoodEntry from './pages/MoodEntry';
 import Calendar from './pages/Calendar';
 import TherapyScheduler from './pages/TherapyScheduler';
 import Timer from './pages/Timer';
+import Analytics from './pages/Analytics';
 import WelcomeCarousel from './components/WelcomeCarousel';
 import { useThemeStore } from './contexts/useThemeStore';
 import { getSeasonColors } from './utils/getSeasonColors';
@@ -85,6 +86,7 @@ function InnerApp() {
         <Route path="/mood" element={<MoodEntry />} />
         <Route path="/calendar" element={<Calendar />} />
         <Route path="/scheduler" element={<TherapyScheduler />} />
+        <Route path="/analytics" element={<Analytics />} />
         <Route path="/timer" element={<Timer />} />
       </Routes>
     </div>

--- a/src/components/MoodAnalytics.tsx
+++ b/src/components/MoodAnalytics.tsx
@@ -1,0 +1,87 @@
+import React from 'react'
+import { Line } from 'react-chartjs-2'
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  Title,
+  Tooltip,
+  Legend,
+} from 'chart.js'
+import { format } from 'date-fns'
+import { useMoodStore } from '../contexts/useMoodStore'
+import { computeWeeklySummary } from '../contexts/analytics'
+
+ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Title, Tooltip, Legend)
+
+export default function MoodAnalytics() {
+  const entries = useMoodStore((state) => state.entries)
+
+  const labels = entries.map((e) => format(e.timestamp, 'MM/dd'))
+  const moodData = entries.map((e) => e.mood)
+  const lightData = entries.map((e) => e.light)
+
+  const lineChartData = {
+    labels,
+    datasets: [
+      {
+        label: 'Mood',
+        data: moodData,
+        borderColor: 'rgb(75, 192, 192)',
+        backgroundColor: 'rgba(75, 192, 192, 0.2)',
+        tension: 0.3,
+      },
+    ],
+  }
+
+  const combinedData = {
+    labels,
+    datasets: [
+      {
+        label: 'Mood',
+        data: moodData,
+        borderColor: 'rgb(255, 99, 132)',
+        tension: 0.3,
+        yAxisID: 'y1',
+      },
+      {
+        label: 'Light',
+        data: lightData,
+        borderColor: 'rgb(54, 162, 235)',
+        tension: 0.3,
+        yAxisID: 'y2',
+      },
+    ],
+  }
+
+  const summary = React.useMemo(() => computeWeeklySummary(entries), [entries])
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h2 className="font-bold mb-2">Mood Over Time</h2>
+        <Line data={lineChartData} />
+      </div>
+      <div>
+        <h2 className="font-bold mb-2">Mood vs Light</h2>
+        <Line
+          data={combinedData}
+          options={{
+            scales: {
+              y1: { type: 'linear', position: 'left', min: 0, max: 5 },
+              y2: { type: 'linear', position: 'right', min: 0, max: 10 },
+            },
+          }}
+        />
+      </div>
+      <div className="p-4 border rounded">
+        <h3 className="font-bold mb-2">Last 7 Days Summary</h3>
+        <p>Average Mood: {summary.averageMood.toFixed(2)}</p>
+        <p>Highest Mood Day: {summary.highestMoodDay}</p>
+        <p>Total Light Exposure: {summary.totalLight}</p>
+      </div>
+    </div>
+  )
+}

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -9,6 +9,7 @@ export default function NavBar() {
       <Link to="/mood" className="text-blue-600 dark:text-blue-400">Mood</Link>
       <Link to="/calendar" className="text-blue-600 dark:text-blue-400">Calendar</Link>
       <Link to="/scheduler" className="text-blue-600 dark:text-blue-400">Scheduler</Link>
+      <Link to="/analytics" className="text-blue-600 dark:text-blue-400">Analytics</Link>
       <Link to="/timer" className="text-blue-600 dark:text-blue-400">Timer</Link>
     </nav>
   );

--- a/src/contexts/analytics.test.ts
+++ b/src/contexts/analytics.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest'
+import { computeWeeklySummary } from './analytics'
+import type { MoodEntry } from './useMoodStore'
+import { startOfDay, subDays } from 'date-fns'
+
+describe('computeWeeklySummary', () => {
+  it('calculates stats for the last seven days', () => {
+    const base = startOfDay(new Date('2025-06-20')).getTime()
+    const entries: MoodEntry[] = [
+      { timestamp: subDays(base, 8).getTime(), mood: 1, energy: 0, sleep: 0, light: 1, notes: '' },
+      { timestamp: subDays(base, 2).getTime(), mood: 5, energy: 0, sleep: 0, light: 3, notes: '' },
+      { timestamp: subDays(base, 1).getTime(), mood: 3, energy: 0, sleep: 0, light: 4, notes: '' },
+      { timestamp: base, mood: 4, energy: 0, sleep: 0, light: 5, notes: '' },
+    ]
+
+    const summary = computeWeeklySummary(entries, base)
+
+    expect(summary.averageMood).toBeCloseTo((5 + 3 + 4) / 3)
+    expect(summary.totalLight).toBe(3 + 4 + 5)
+    expect(summary.highestMoodDay).toBe('Wed')
+  })
+})

--- a/src/contexts/analytics.ts
+++ b/src/contexts/analytics.ts
@@ -1,0 +1,25 @@
+import { format, startOfDay, subDays } from 'date-fns'
+import type { MoodEntry } from './useMoodStore'
+
+export interface WeeklySummary {
+  averageMood: number
+  highestMoodDay: string
+  totalLight: number
+}
+
+export function computeWeeklySummary(entries: MoodEntry[], now = Date.now()): WeeklySummary {
+  const weekStart = subDays(startOfDay(now), 6).getTime()
+  const recent = entries.filter((e) => e.timestamp >= weekStart)
+  if (recent.length === 0) {
+    return { averageMood: 0, highestMoodDay: '', totalLight: 0 }
+  }
+  const totalMood = recent.reduce((sum, e) => sum + e.mood, 0)
+  const totalLight = recent.reduce((sum, e) => sum + e.light, 0)
+  const avgMood = totalMood / recent.length
+  const highest = recent.reduce((max, e) => (e.mood > max.mood ? e : max), recent[0])
+  return {
+    averageMood: avgMood,
+    highestMoodDay: format(highest.timestamp, 'EEE'),
+    totalLight,
+  }
+}

--- a/src/pages/Analytics.tsx
+++ b/src/pages/Analytics.tsx
@@ -1,0 +1,11 @@
+import React from 'react'
+import MoodAnalytics from '../components/MoodAnalytics'
+
+export default function Analytics() {
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl font-bold mb-4">Analytics</h1>
+      <MoodAnalytics />
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- install `chart.js` and `react-chartjs-2`
- visualize mood trends with new `MoodAnalytics` component
- compute weekly mood stats in `computeWeeklySummary`
- add Analytics page and link from NavBar and router
- document chart usage in README
- test summary calculations

## Testing
- `npm run lint`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6851d697f9b8832fa506cd89b2ff1fda