### PR TITLE
Add sunrise/sunset info to mood entries

### DIFF
--- a/src/contexts/useMoodStore.test.ts
+++ b/src/contexts/useMoodStore.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { useMoodStore } from './useMoodStore'
 
 declare global {
@@ -23,6 +23,12 @@ beforeEach(() => {
       },
     },
   } as Navigator
+  global.fetch = vi.fn().mockResolvedValue({
+    json: async () => ({
+      status: 'OK',
+      results: { sunrise: '06:00', sunset: '18:00' },
+    }),
+  } as Response)
 })
 
 describe('useMoodStore', () => {
@@ -30,6 +36,9 @@ describe('useMoodStore', () => {
     const store = useMoodStore.getState()
     await store.addEntry({ mood: 3, energy: 2, sleep: 1, light: 4, notes: 'ok' })
     expect(store.getEntries()).toHaveLength(1)
+    const entry = store.getEntries()[0]
+    expect(entry.sunrise).toBe('06:00')
+    expect(entry.sunset).toBe('18:00')
     expect(store.getStreak()).toBe(1)
   })
 })

--- a/src/contexts/useMoodStore.ts
+++ b/src/contexts/useMoodStore.ts
@@ -9,11 +9,15 @@ export interface MoodEntry {
   light: number;
   notes: string;
   coords?: { latitude: number; longitude: number };
+  sunrise?: string;
+  sunset?: string;
 }
 
 interface MoodState {
   entries: MoodEntry[];
-  addEntry: (data: Omit<MoodEntry, 'timestamp' | 'coords'>) => Promise<void>;
+  addEntry: (
+    data: Omit<MoodEntry, 'timestamp' | 'coords' | 'sunrise' | 'sunset'>,
+  ) => Promise<void>;
   getEntries: () => MoodEntry[];
   getStreak: () => number;
 }
@@ -38,6 +42,19 @@ export const useMoodStore = create<MoodState>((set, get) => ({
           latitude: coords.latitude,
           longitude: coords.longitude,
         };
+
+        try {
+          const res = await fetch(
+            `https://api.sunrise-sunset.org/json?lat=${coords.latitude}&lng=${coords.longitude}&formatted=0`,
+          );
+          const json = await res.json();
+          if (json.status === 'OK') {
+            entry.sunrise = json.results.sunrise;
+            entry.sunset = json.results.sunset;
+          }
+        } catch {
+          // ignore fetch errors
+        }
       } catch {
         // ignore geolocation errors
       }


### PR DESCRIPTION
## Summary
- add optional `sunrise` and `sunset` fields to mood entries
- fetch daily sunlight times during `addEntry`
- verify new behaviour in unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6851e3c2b714832fa71c022dddd529cc