### PR TITLE
Add daily tip feature

### DIFF
--- a/src/components/ContentFeed.tsx
+++ b/src/components/ContentFeed.tsx
@@ -1,25 +1,33 @@
-import React from 'react';
-
-const tips: string[] = [
-  'Take a short walk outside.',
-  'Write down something you\'re grateful for.',
-  'Practice deep breathing for one minute.',
-  'Reach out to a friend or family member.',
-  'Take a moment to stretch.',
-];
+import React from 'react'
+import { useMoodStore } from '../contexts/useMoodStore'
+import { selectTip } from '../utils/selectTip'
 
 export default function ContentFeed() {
-  return (
-    <div className="h-48 overflow-y-auto scroll-smooth space-y-2 p-2 border rounded">
-      {tips.map((tip, index) => (
-        <div
-          key={index}
-          className="p-2 bg-gray-100 dark:bg-gray-700 rounded"
-        >
-          {tip}
-        </div>
-      ))}
-    </div>
-  );
-}
+  const entries = useMoodStore((state) => state.entries)
+  const [tip, setTip] = React.useState('')
 
+  React.useEffect(() => {
+    const today = new Date().toDateString()
+    const stored = localStorage.getItem('dailyTip')
+    if (stored) {
+      try {
+        const parsed = JSON.parse(stored) as { date: string; tip: string }
+        if (parsed.date === today) {
+          setTip(parsed.tip)
+          return
+        }
+      } catch {
+        // ignore parse errors
+      }
+    }
+    const newTip = selectTip(entries)
+    localStorage.setItem('dailyTip', JSON.stringify({ date: today, tip: newTip }))
+    setTip(newTip)
+  }, [entries])
+
+  if (!tip) return null
+
+  return (
+    <div className="p-2 border rounded bg-gray-100 dark:bg-gray-700">{tip}</div>
+  )
+}

--- a/src/tips/tips.json
+++ b/src/tips/tips.json
@@ -1,0 +1,8 @@
+[
+  { "text": "Open the curtains to let in sunlight.", "condition": "lowLight" },
+  { "text": "Take a short walk outside.", "condition": "lowLight" },
+  { "text": "Write down something you're grateful for.", "condition": "lowMood" },
+  { "text": "Reach out to a friend or family member.", "condition": "lowMood" },
+  { "text": "Practice deep breathing for one minute.", "condition": "any" },
+  { "text": "Take a moment to stretch.", "condition": "any" }
+]

--- a/src/utils/selectTip.test.ts
+++ b/src/utils/selectTip.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { selectTip } from './selectTip'
+import tips from '../tips/tips.json' assert { type: 'json' }
+import type { MoodEntry } from '../contexts/useMoodStore'
+
+describe('selectTip', () => {
+  beforeEach(() => {
+    vi.spyOn(Math, 'random').mockReturnValue(0)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns a low mood tip when mood is low', () => {
+    const entries: MoodEntry[] = [{ timestamp: 0, mood: 1, energy: 0, sleep: 0, light: 5, notes: '' }]
+    const tip = selectTip(entries)
+    const all = tips as { text: string; condition: string }[]
+    const expected = all.filter((t) => t.condition === 'lowMood' || t.condition === 'any')[0].text
+    expect(tip).toBe(expected)
+  })
+})

--- a/src/utils/selectTip.ts
+++ b/src/utils/selectTip.ts
@@ -1,0 +1,24 @@
+import tips from '../tips/tips.json' assert { type: 'json' }
+import type { MoodEntry } from '../contexts/useMoodStore'
+
+export interface Tip {
+  text: string
+  condition: 'any' | 'lowLight' | 'lowMood'
+}
+
+const allTips = tips as Tip[]
+
+export function selectTip(entries: MoodEntry[]): string {
+  const recent = entries.slice(-3)
+  let cond: Tip['condition'] = 'any'
+  if (recent.length > 0) {
+    const avgMood = recent.reduce((s, e) => s + e.mood, 0) / recent.length
+    const avgLight = recent.reduce((s, e) => s + e.light, 0) / recent.length
+    if (avgMood <= 2) cond = 'lowMood'
+    else if (avgLight <= 3) cond = 'lowLight'
+  }
+  const candidates = allTips.filter(
+    (t) => t.condition === cond || t.condition === 'any'
+  )
+  return candidates[Math.floor(Math.random() * candidates.length)].text
+}


### PR DESCRIPTION
## Summary
- store motivational tips in JSON
- choose a tip based on recent mood/light via `selectTip`
- display one daily tip in `ContentFeed`
- add tests for the selection utility

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6851e7d6d5c0832fa105dde2e02ec145