### PR TITLE
Implement weather data for mood entries

### DIFF
--- a/src/contexts/useMoodStore.test.ts
+++ b/src/contexts/useMoodStore.test.ts
@@ -23,12 +23,21 @@ beforeEach(() => {
       },
     },
   } as Navigator
-  global.fetch = vi.fn().mockResolvedValue({
-    json: async () => ({
-      status: 'OK',
-      results: { sunrise: '06:00', sunset: '18:00' },
-    }),
-  } as Response)
+  let call = 0
+  global.fetch = vi.fn().mockImplementation(() => {
+    call++
+    if (call === 1) {
+      return Promise.resolve({
+        json: async () => ({
+          status: 'OK',
+          results: { sunrise: '06:00', sunset: '18:00' },
+        }),
+      } as Response)
+    }
+    return Promise.resolve({
+      json: async () => ({ current_weather: { weathercode: 2 } }),
+    } as Response)
+  })
 })
 
 describe('useMoodStore', () => {
@@ -39,6 +48,7 @@ describe('useMoodStore', () => {
     const entry = store.getEntries()[0]
     expect(entry.sunrise).toBe('06:00')
     expect(entry.sunset).toBe('18:00')
+    expect(entry.weather).toBe('cloudy')
     expect(store.getStreak()).toBe(1)
   })
 })


### PR DESCRIPTION
## Summary
- add weather field to MoodEntry and fetch from Open-Meteo
- capture weather information in addEntry
- update useMoodStore tests for weather

## Testing
- `npx vitest run`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6851e0cef5a0832f8b2480617f5ed3f2