### PR TITLE
Streamline mood entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ browser.
 
 ## Features
 
-- **Mood Entry** – track mood, energy, sleep quality, light exposure and notes.
+- **Mood Entry** – track mood and optional notes.
   When geolocation is available the entry is tagged with your coordinates.
 - **Calendar** – view past entries on a monthly calendar and tap a day to see
   details.
@@ -16,7 +16,7 @@ browser.
 - **Customization** – toggle dark mode, choose a seasonal theme (Spring, Summer,
   Autumn or Winter), adjust notification frequency and set a daily check-in time.
 - **Streak Counter** – see how many days in a row you've entered your mood.
-- **Analytics** – visualize mood trends and light exposure with interactive charts.
+- **Analytics** – visualize mood trends with interactive charts.
 
 ## Browser requirements
 

--- a/src/components/MoodAnalytics.tsx
+++ b/src/components/MoodAnalytics.tsx
@@ -21,7 +21,6 @@ export default function MoodAnalytics() {
 
   const labels = entries.map((e) => format(e.timestamp, 'MM/dd'))
   const moodData = entries.map((e) => e.mood)
-  const lightData = entries.map((e) => e.light)
 
   const lineChartData = {
     labels,
@@ -36,26 +35,6 @@ export default function MoodAnalytics() {
     ],
   }
 
-  const combinedData = {
-    labels,
-    datasets: [
-      {
-        label: 'Mood',
-        data: moodData,
-        borderColor: 'rgb(255, 99, 132)',
-        tension: 0.3,
-        yAxisID: 'y1',
-      },
-      {
-        label: 'Light',
-        data: lightData,
-        borderColor: 'rgb(54, 162, 235)',
-        tension: 0.3,
-        yAxisID: 'y2',
-      },
-    ],
-  }
-
   const summary = React.useMemo(() => computeWeeklySummary(entries), [entries])
 
   return (
@@ -64,23 +43,10 @@ export default function MoodAnalytics() {
         <h2 className="font-bold mb-2">Mood Over Time</h2>
         <Line data={lineChartData} />
       </div>
-      <div>
-        <h2 className="font-bold mb-2">Mood vs Light</h2>
-        <Line
-          data={combinedData}
-          options={{
-            scales: {
-              y1: { type: 'linear', position: 'left', min: 0, max: 5 },
-              y2: { type: 'linear', position: 'right', min: 0, max: 10 },
-            },
-          }}
-        />
-      </div>
       <div className="p-4 border rounded">
         <h3 className="font-bold mb-2">Last 7 Days Summary</h3>
         <p>Average Mood: {summary.averageMood.toFixed(2)}</p>
         <p>Highest Mood Day: {summary.highestMoodDay}</p>
-        <p>Total Light Exposure: {summary.totalLight}</p>
       </div>
     </div>
   )

--- a/src/contexts/analytics.test.ts
+++ b/src/contexts/analytics.test.ts
@@ -7,16 +7,15 @@ describe('computeWeeklySummary', () => {
   it('calculates stats for the last seven days', () => {
     const base = startOfDay(new Date('2025-06-20')).getTime()
     const entries: MoodEntry[] = [
-      { timestamp: subDays(base, 8).getTime(), mood: 1, energy: 0, sleep: 0, light: 1, notes: '' },
-      { timestamp: subDays(base, 2).getTime(), mood: 5, energy: 0, sleep: 0, light: 3, notes: '' },
-      { timestamp: subDays(base, 1).getTime(), mood: 3, energy: 0, sleep: 0, light: 4, notes: '' },
-      { timestamp: base, mood: 4, energy: 0, sleep: 0, light: 5, notes: '' },
+      { timestamp: subDays(base, 8).getTime(), mood: 1, notes: '' },
+      { timestamp: subDays(base, 2).getTime(), mood: 5, notes: '' },
+      { timestamp: subDays(base, 1).getTime(), mood: 3, notes: '' },
+      { timestamp: base, mood: 4, notes: '' },
     ]
 
     const summary = computeWeeklySummary(entries, base)
 
     expect(summary.averageMood).toBeCloseTo((5 + 3 + 4) / 3)
-    expect(summary.totalLight).toBe(3 + 4 + 5)
     expect(summary.highestMoodDay).toBe('Wed')
   })
 })

--- a/src/contexts/analytics.ts
+++ b/src/contexts/analytics.ts
@@ -4,22 +4,19 @@ import type { MoodEntry } from './useMoodStore'
 export interface WeeklySummary {
   averageMood: number
   highestMoodDay: string
-  totalLight: number
 }
 
 export function computeWeeklySummary(entries: MoodEntry[], now = Date.now()): WeeklySummary {
   const weekStart = subDays(startOfDay(now), 6).getTime()
   const recent = entries.filter((e) => e.timestamp >= weekStart)
   if (recent.length === 0) {
-    return { averageMood: 0, highestMoodDay: '', totalLight: 0 }
+    return { averageMood: 0, highestMoodDay: '' }
   }
   const totalMood = recent.reduce((sum, e) => sum + e.mood, 0)
-  const totalLight = recent.reduce((sum, e) => sum + e.light, 0)
   const avgMood = totalMood / recent.length
   const highest = recent.reduce((max, e) => (e.mood > max.mood ? e : max), recent[0])
   return {
     averageMood: avgMood,
     highestMoodDay: format(highest.timestamp, 'EEE'),
-    totalLight,
   }
 }

--- a/src/contexts/useMoodStore.test.ts
+++ b/src/contexts/useMoodStore.test.ts
@@ -43,7 +43,7 @@ beforeEach(() => {
 describe('useMoodStore', () => {
   it('adds an entry and computes streak', async () => {
     const store = useMoodStore.getState()
-    await store.addEntry({ mood: 3, energy: 2, sleep: 1, light: 4, notes: 'ok' })
+    await store.addEntry({ mood: 3, notes: 'ok' })
     expect(store.getEntries()).toHaveLength(1)
     const entry = store.getEntries()[0]
     expect(entry.sunrise).toBe('06:00')

--- a/src/contexts/useMoodStore.ts
+++ b/src/contexts/useMoodStore.ts
@@ -4,9 +4,6 @@ import { format, subDays, startOfDay } from 'date-fns';
 export interface MoodEntry {
   timestamp: number;
   mood: number;
-  energy: number;
-  sleep: number;
-  light: number;
   notes: string;
   coords?: { latitude: number; longitude: number };
   sunrise?: string;
@@ -17,7 +14,7 @@ export interface MoodEntry {
 interface MoodState {
   entries: MoodEntry[];
   addEntry: (
-    data: Omit<MoodEntry, 'timestamp' | 'coords' | 'sunrise' | 'sunset' | 'weather'>,
+    data: Pick<MoodEntry, 'mood' | 'notes'>,
   ) => Promise<void>;
   getEntries: () => MoodEntry[];
   getStreak: () => number;

--- a/src/pages/Calendar.tsx
+++ b/src/pages/Calendar.tsx
@@ -26,9 +26,6 @@ function DayDetailModal({ date, entry, onClose }: DayDetailModalProps) {
         {entry ? (
           <div className="space-y-1">
             <p>Mood: {entry.mood}</p>
-            <p>Energy: {entry.energy}</p>
-            <p>Sleep: {entry.sleep}</p>
-            <p>Light: {entry.light}</p>
             {entry.notes && <p>Notes: {entry.notes}</p>}
           </div>
         ) : (

--- a/src/pages/MoodEntry.tsx
+++ b/src/pages/MoodEntry.tsx
@@ -9,13 +9,10 @@ export default function MoodEntry() {
   const { setLastPrompt } = useCheckInStore();
   const { addEntry } = useMoodStore();
   const [mood, setMood] = useState(3);
-  const [energy, setEnergy] = useState(5);
-  const [sleep, setSleep] = useState(5);
-  const [light, setLight] = useState(5);
   const [notes, setNotes] = useState('');
 
   const handleSave = () => {
-    addEntry({ mood, energy, sleep, light, notes });
+    addEntry({ mood, notes });
     setNotes('');
   };
 
@@ -36,8 +33,8 @@ export default function MoodEntry() {
               onClick={() => setMood(index + 1)}
               aria-label={moodLabels[index]}
               className={
-                'text-3xl transition transform focus:outline-none focus:ring-2 focus:ring-primary ' +
-                (mood === index + 1 ? 'scale-125' : 'opacity-50')
+                'w-12 h-12 flex items-center justify-center rounded-full border text-3xl transition transform focus:outline-none focus:ring-2 focus:ring-primary ' +
+                (mood === index + 1 ? 'scale-110' : 'opacity-50')
               }
             >
               {emoji}
@@ -46,50 +43,6 @@ export default function MoodEntry() {
         </div>
       </div>
 
-      <div>
-        <label htmlFor="energy" className="block mb-1">
-          Energy Level: {energy}
-        </label>
-        <input
-          id="energy"
-          type="range"
-          min="1"
-          max="10"
-          value={energy}
-          onChange={(e) => setEnergy(Number(e.target.value))}
-          className="w-full"
-        />
-      </div>
-
-      <div>
-        <label htmlFor="sleep" className="block mb-1">
-          Sleep Quality: {sleep}
-        </label>
-        <input
-          id="sleep"
-          type="range"
-          min="1"
-          max="10"
-          value={sleep}
-          onChange={(e) => setSleep(Number(e.target.value))}
-          className="w-full"
-        />
-      </div>
-
-      <div>
-        <label htmlFor="light" className="block mb-1">
-          Light Exposure: {light}
-        </label>
-        <input
-          id="light"
-          type="range"
-          min="1"
-          max="10"
-          value={light}
-          onChange={(e) => setLight(Number(e.target.value))}
-          className="w-full"
-        />
-      </div>
 
       <div>
         <label htmlFor="notes" className="block mb-1">
@@ -99,7 +52,7 @@ export default function MoodEntry() {
           id="notes"
           value={notes}
           onChange={(e) => setNotes(e.target.value)}
-          className="w-full p-2 border rounded text-indigo dark:text-creamWhite"
+          className="w-full p-2 border rounded bg-creamWhite text-indigo dark:text-creamWhite"
           rows={4}
         />
       </div>

--- a/src/utils/selectTip.test.ts
+++ b/src/utils/selectTip.test.ts
@@ -13,7 +13,7 @@ describe('selectTip', () => {
   })
 
   it('returns a low mood tip when mood is low', () => {
-    const entries: MoodEntry[] = [{ timestamp: 0, mood: 1, energy: 0, sleep: 0, light: 5, notes: '' }]
+    const entries: MoodEntry[] = [{ timestamp: 0, mood: 1, notes: '' }]
     const tip = selectTip(entries)
     const all = tips as { text: string; condition: string }[]
     const expected = all.filter((t) => t.condition === 'lowMood' || t.condition === 'any')[0].text

--- a/src/utils/selectTip.ts
+++ b/src/utils/selectTip.ts
@@ -13,9 +13,7 @@ export function selectTip(entries: MoodEntry[]): string {
   let cond: Tip['condition'] = 'any'
   if (recent.length > 0) {
     const avgMood = recent.reduce((s, e) => s + e.mood, 0) / recent.length
-    const avgLight = recent.reduce((s, e) => s + e.light, 0) / recent.length
     if (avgMood <= 2) cond = 'lowMood'
-    else if (avgLight <= 3) cond = 'lowLight'
   }
   const candidates = allTips.filter(
     (t) => t.condition === cond || t.condition === 'any'


### PR DESCRIPTION
## Summary
- simplify MoodEntry component to just mood and notes
- drop energy, sleep and light fields from mood data
- adjust analytics and tips to match new schema
- refresh calendar and analytics displays
- update README

## Testing
- `npx vitest run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6851fec9cebc832f9798e09923231d98