### PR TITLE
Add challenge progress feature

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import Calendar from './pages/Calendar';
 import TherapyScheduler from './pages/TherapyScheduler';
 import Analytics from './pages/Analytics';
 import TipOfTheDay from './pages/TipOfTheDay';
+import Challenge from './pages/Challenge';
 import WelcomeCarousel from './components/WelcomeCarousel';
 import { useThemeStore } from './contexts/useThemeStore';
 import { getSeasonColors } from './utils/getSeasonColors';
@@ -127,6 +128,7 @@ function InnerApp() {
         <Route path="/mood" element={<MoodEntry />} />
         <Route path="/calendar" element={<Calendar />} />
         <Route path="/scheduler" element={<TherapyScheduler />} />
+        <Route path="/challenge" element={<Challenge />} />
         <Route path="/analytics" element={<Analytics />} />
         <Route path="/tip" element={<TipOfTheDay />} />
       </Routes>

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -45,6 +45,13 @@ export default function NavBar() {
         Scheduler
       </NavLink>
       <NavLink
+        to="/challenge"
+        className={linkClass}
+        onClick={() => setOpen(false)}
+      >
+        Challenge
+      </NavLink>
+      <NavLink
         to="/analytics"
         className={linkClass}
         onClick={() => setOpen(false)}

--- a/src/contexts/useChallengeStore.ts
+++ b/src/contexts/useChallengeStore.ts
@@ -1,0 +1,42 @@
+import { create } from 'zustand'
+
+interface ChallengeState {
+  steps: string[]
+  joined: boolean
+  current: number
+  join: () => void
+  completeStep: () => void
+  reset: () => void
+}
+
+const stepList = [
+  'Reflect on your mood',
+  'Take a short walk',
+  'Write down something you are grateful for',
+  'Connect with a friend',
+  'Do a relaxing activity',
+]
+
+const initialJoined = localStorage.getItem('challengeJoined') === 'true'
+const initialCurrent = parseInt(localStorage.getItem('challengeCurrent') || '0', 10)
+
+export const useChallengeStore = create<ChallengeState>((set, get) => ({
+  steps: stepList,
+  joined: initialJoined,
+  current: initialCurrent,
+  join: () => {
+    localStorage.setItem('challengeJoined', 'true')
+    localStorage.setItem('challengeCurrent', '0')
+    set({ joined: true, current: 0 })
+  },
+  completeStep: () => {
+    const next = Math.min(get().current + 1, stepList.length)
+    localStorage.setItem('challengeCurrent', String(next))
+    set({ current: next })
+  },
+  reset: () => {
+    localStorage.removeItem('challengeJoined')
+    localStorage.removeItem('challengeCurrent')
+    set({ joined: false, current: 0 })
+  },
+}))

--- a/src/pages/Challenge.tsx
+++ b/src/pages/Challenge.tsx
@@ -1,0 +1,65 @@
+import { motion } from 'framer-motion'
+import { useChallengeStore } from '../contexts/useChallengeStore'
+
+function Confetti() {
+  const colors = ['#FFD761', '#3b82f6', '#E5F0FB']
+  const pieces = Array.from({ length: 25 }, (_, i) => i)
+  return (
+    <div className="fixed inset-0 pointer-events-none overflow-hidden">
+      {pieces.map((p) => {
+        const left = Math.random() * 100
+        const delay = Math.random() * 0.3
+        const bg = colors[p % colors.length]
+        return (
+          <motion.div
+            key={p}
+            style={{ left: `${left}%`, backgroundColor: bg }}
+            className="absolute top-0 w-2 h-2"
+            initial={{ opacity: 1, y: 0, rotate: 0 }}
+            animate={{ opacity: 0, y: '100vh', rotate: 360 }}
+            transition={{ duration: 2, delay }}
+          />
+        )
+      })}
+    </div>
+  )
+}
+
+export default function Challenge() {
+  const { steps, joined, current, join, completeStep } = useChallengeStore()
+  const completed = current >= steps.length
+  const progress = (current / steps.length) * 100
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-2xl font-bold">30 Day Challenge</h1>
+      <div className="h-4 bg-mutedBlueGray rounded-full overflow-hidden">
+        <div
+          className="h-full bg-gradient-to-r from-primary to-yellow"
+          style={{ width: `${progress}%` }}
+        />
+      </div>
+      <ul className="space-y-1">
+        {steps.map((s, i) => (
+          <li key={s} className={i < current ? 'line-through' : ''}>
+            {s}
+          </li>
+        ))}
+      </ul>
+      {!joined && (
+        <button onClick={join} className="px-4 py-2 bg-primary text-white rounded">
+          Join Challenge
+        </button>
+      )}
+      {joined && !completed && (
+        <button
+          onClick={completeStep}
+          className="px-4 py-2 bg-yellow text-indigo rounded"
+        >
+          Complete Step
+        </button>
+      )}
+      {completed && <Confetti />}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add zustand challenge store to track steps and completion
- implement Challenge page with progress bar and confetti animation
- add Challenge page to router and navbar

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685204504344832f84f061e18097bbc7