### PR TITLE
Add premium trial modal

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,8 @@ import { getSeasonColors } from './utils/getSeasonColors';
 import PermissionsPrompt from './components/PermissionsPrompt';
 import { usePermissionStore } from './contexts/usePermissionStore';
 import { useCheckInStore } from './contexts/useCheckInStore';
+import PremiumModal from './components/PremiumModal';
+import { usePremiumStore } from './contexts/usePremiumStore';
 import './index.css';
 
 function InnerApp() {
@@ -26,6 +28,15 @@ function InnerApp() {
   const location = useLocation();
   const navigate = useNavigate();
   const [showCheckIn, setShowCheckIn] = React.useState(false);
+  const {
+    firstUse,
+    dismissed: premiumDismissed,
+    trialStarted,
+    setDismissed,
+    startTrial,
+  } = usePremiumStore();
+  const [showPremium, setShowPremium] = React.useState(false);
+  const PREMIUM_DAYS = 7;
 
   React.useEffect(() => {
     if (
@@ -47,6 +58,13 @@ function InnerApp() {
       setShowCheckIn(true);
     }
   }, [lastPrompt, location.pathname]);
+
+  React.useEffect(() => {
+    const daysUsed = (Date.now() - firstUse) / (24 * 60 * 60 * 1000);
+    if (!premiumDismissed && !trialStarted && daysUsed >= PREMIUM_DAYS) {
+      setShowPremium(true);
+    }
+  }, [firstUse, premiumDismissed, trialStarted]);
 
   React.useEffect(() => {
     if (typeof window === 'undefined' || !('Notification' in window)) {
@@ -95,6 +113,16 @@ function InnerApp() {
     navigate('/mood');
   };
 
+  const handleStartTrial = () => {
+    startTrial();
+    setShowPremium(false);
+  };
+
+  const handleDismissPremium = () => {
+    setDismissed(true);
+    setShowPremium(false);
+  };
+
   return (
     <div
       className={`min-h-screen ${
@@ -114,6 +142,12 @@ function InnerApp() {
             </button>
           </div>
         </div>
+      )}
+      {showPremium && (
+        <PremiumModal
+          onStart={handleStartTrial}
+          onClose={handleDismissPremium}
+        />
       )}
       <button onClick={toggle} className="m-4 p-2 border rounded">
         Toggle Theme

--- a/src/components/PremiumModal.tsx
+++ b/src/components/PremiumModal.tsx
@@ -1,0 +1,31 @@
+import React from 'react'
+
+interface PremiumModalProps {
+  onStart: () => void
+  onClose: () => void
+}
+
+export default function PremiumModal({ onStart, onClose }: PremiumModalProps) {
+  return (
+    <div className="fixed inset-0 flex items-center justify-center bg-primary-light bg-opacity-90 z-50 p-4">
+      <div className="bg-white p-6 rounded shadow max-w-sm w-full text-center">
+        <h2 className="text-xl font-bold mb-2">Unlock Premium Analytics</h2>
+        <p className="mb-4">See your 60-day mood trends and more.</p>
+        <div className="flex justify-center gap-4">
+          <button
+            onClick={onStart}
+            className="px-4 py-2 bg-primary text-white rounded"
+          >
+            Start Free Trial
+          </button>
+          <button
+            onClick={onClose}
+            className="px-4 py-2 border rounded"
+          >
+            Maybe Later
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/contexts/usePremiumStore.ts
+++ b/src/contexts/usePremiumStore.ts
@@ -1,0 +1,31 @@
+import { create } from 'zustand'
+
+interface PremiumState {
+  firstUse: number
+  dismissed: boolean
+  trialStarted: boolean
+  setDismissed: (val: boolean) => void
+  startTrial: () => void
+}
+
+const storedFirst = parseInt(localStorage.getItem('firstUse') || '0', 10)
+const initialFirst = storedFirst || Date.now()
+if (!storedFirst) {
+  localStorage.setItem('firstUse', String(initialFirst))
+}
+const storedDismissed = localStorage.getItem('premiumDismissed') === 'true'
+const storedTrial = localStorage.getItem('trialStarted') === 'true'
+
+export const usePremiumStore = create<PremiumState>((set) => ({
+  firstUse: initialFirst,
+  dismissed: storedDismissed,
+  trialStarted: storedTrial,
+  setDismissed: (val) => {
+    localStorage.setItem('premiumDismissed', String(val))
+    set({ dismissed: val })
+  },
+  startTrial: () => {
+    localStorage.setItem('trialStarted', 'true')
+    set({ trialStarted: true })
+  },
+}))

--- a/src/pages/Analytics.tsx
+++ b/src/pages/Analytics.tsx
@@ -1,10 +1,30 @@
+import React from 'react'
 import MoodAnalytics from '../components/MoodAnalytics'
+import PremiumModal from '../components/PremiumModal'
+import { usePremiumStore } from '../contexts/usePremiumStore'
 
 export default function Analytics() {
+  const { trialStarted, startTrial } = usePremiumStore()
+  const [showPremium, setShowPremium] = React.useState(false)
+
+  const openPremium = () => setShowPremium(true)
+  const closePremium = () => setShowPremium(false)
+
   return (
     <div className="p-4">
       <h1 className="text-2xl font-bold mb-4">Analytics</h1>
       <MoodAnalytics />
+      {!trialStarted && (
+        <button
+          onClick={openPremium}
+          className="mt-4 px-4 py-2 bg-primary text-white rounded"
+        >
+          See your 60-day trend
+        </button>
+      )}
+      {showPremium && (
+        <PremiumModal onStart={startTrial} onClose={closePremium} />
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- create `PremiumModal` component
- track first use and trial state in `usePremiumStore`
- show modal after a week of use or when 60‑day analytics are requested

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: dependencies missing)*
- `npm run build` *(fails: missing deps)*

------
https://chatgpt.com/codex/tasks/task_e_685205c2d238832fab04a255964658bc