### PR TITLE
Enhance accessibility

### DIFF
--- a/scripts/check-contrast.js
+++ b/scripts/check-contrast.js
@@ -1,0 +1,40 @@
+const colors = {
+  primary: '#3b82f6',
+  primaryDark: '#1e40af',
+  primaryLight: '#93c5fd',
+  yellow: '#FFD761',
+  paleSky: '#E5F0FB',
+  indigo: '#1D3557',
+  creamWhite: '#FFFDF8',
+  mutedBlueGray: '#B7C9D4',
+  white: '#ffffff',
+}
+function hexToRgb(hex){
+  hex=hex.replace('#','');
+  if(hex.length===3) hex=hex[0]+hex[0]+hex[1]+hex[1]+hex[2]+hex[2];
+  const int=parseInt(hex,16);
+  return [int>>16 & 255, int>>8 & 255, int & 255];
+}
+function luminance([r,g,b]){
+  const sr=[r,g,b].map(c=>{
+    c/=255;
+    return c<=0.03928? c/12.92: Math.pow((c+0.055)/1.055,2.4);
+  });
+  return 0.2126*sr[0]+0.7152*sr[1]+0.0722*sr[2];
+}
+function contrast(a,b){
+  const l1=luminance(hexToRgb(a));
+  const l2=luminance(hexToRgb(b));
+  const [bright,dark]=l1>l2?[l1,l2]:[l2,l1];
+  return (bright+0.05)/(dark+0.05);
+}
+function check(name, text, bg){
+  const ratio=contrast(colors[text], colors[bg]).toFixed(2);
+  console.log(`${name} text:${text} bg:${bg} ratio:${ratio}`);
+}
+check('White on primary','white','primary');
+check('Yellow on indigo','yellow','indigo');
+check('Indigo on yellow','indigo','yellow');
+check('Indigo on creamWhite','indigo','creamWhite');
+check('CreamWhite on indigo','creamWhite','indigo');
+check('PrimaryDark on creamWhite','primaryDark','creamWhite');

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -136,7 +136,7 @@ function InnerApp() {
             <p className="mb-4">It's time for your daily check-in.</p>
             <button
               onClick={handleCheckIn}
-              className="px-4 py-2 bg-primary text-white rounded"
+              className="px-4 py-2 bg-primary-dark text-white rounded"
             >
               Go to Check-In
             </button>

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -8,30 +8,47 @@ export default function NavBar() {
     [
       'block px-2 py-1 rounded hover:bg-mutedBlueGray dark:hover:bg-indigo',
       isActive
-        ? 'bg-primary text-white dark:bg-primary-dark'
+        ? 'bg-primary-dark text-white dark:bg-primary-dark'
         : 'text-indigo dark:text-yellow',
     ].join(' ');
 
   const links = (
     <>
-      <NavLink to="/home" className={linkClass} onClick={() => setOpen(false)}>
+      <NavLink
+        to="/home"
+        aria-label="Home"
+        className={linkClass}
+        onClick={() => setOpen(false)}
+      >
         Home
       </NavLink>
-      <NavLink to="/about" className={linkClass} onClick={() => setOpen(false)}>
+      <NavLink
+        to="/about"
+        aria-label="About"
+        className={linkClass}
+        onClick={() => setOpen(false)}
+      >
         About
       </NavLink>
       <NavLink
         to="/customize"
+        aria-label="Customize"
         className={linkClass}
         onClick={() => setOpen(false)}
       >
         Customize
       </NavLink>
-      <NavLink to="/mood" className={linkClass} onClick={() => setOpen(false)}>
+      <NavLink
+        to="/mood"
+        aria-label="Mood"
+        className={linkClass}
+        onClick={() => setOpen(false)}
+      >
         Mood
       </NavLink>
       <NavLink
         to="/calendar"
+        aria-label="Calendar"
         className={linkClass}
         onClick={() => setOpen(false)}
       >
@@ -39,6 +56,7 @@ export default function NavBar() {
       </NavLink>
       <NavLink
         to="/scheduler"
+        aria-label="Scheduler"
         className={linkClass}
         onClick={() => setOpen(false)}
       >
@@ -46,6 +64,7 @@ export default function NavBar() {
       </NavLink>
       <NavLink
         to="/challenge"
+        aria-label="Challenge"
         className={linkClass}
         onClick={() => setOpen(false)}
       >
@@ -53,6 +72,7 @@ export default function NavBar() {
       </NavLink>
       <NavLink
         to="/analytics"
+        aria-label="Analytics"
         className={linkClass}
         onClick={() => setOpen(false)}
       >
@@ -67,6 +87,7 @@ export default function NavBar() {
         <button
           className="text-indigo dark:text-yellow"
           onClick={() => setOpen((o) => !o)}
+          aria-label="Toggle navigation"
         >
           &#9776;
         </button>

--- a/src/components/PermissionsPrompt.tsx
+++ b/src/components/PermissionsPrompt.tsx
@@ -57,7 +57,7 @@ export default function PermissionsPrompt() {
         disabled={
           requesting || !notificationsSupported || !geolocationSupported
         }
-        className="px-4 py-2 bg-primary text-white rounded"
+        className="px-4 py-2 bg-primary-dark text-white rounded"
       >
         {requesting ? 'Requesting...' : 'Allow'}
       </button>

--- a/src/components/PremiumModal.tsx
+++ b/src/components/PremiumModal.tsx
@@ -14,7 +14,7 @@ export default function PremiumModal({ onStart, onClose }: PremiumModalProps) {
         <div className="flex justify-center gap-4">
           <button
             onClick={onStart}
-            className="px-4 py-2 bg-primary text-white rounded"
+            className="px-4 py-2 bg-primary-dark text-white rounded"
           >
             Start Free Trial
           </button>

--- a/src/components/WelcomeCarousel.tsx
+++ b/src/components/WelcomeCarousel.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { AnimatePresence, motion } from 'framer-motion';
+import { AnimatePresence, motion, useReducedMotion } from 'framer-motion';
 import { useNavigate } from 'react-router-dom';
 
 interface Slide {
@@ -29,6 +29,7 @@ const slides: Slide[] = [
 export default function WelcomeCarousel() {
   const [index, setIndex] = useState(0);
   const navigate = useNavigate();
+  const shouldReduceMotion = useReducedMotion();
 
   const next = () => {
     if (index < slides.length - 1) {
@@ -50,20 +51,26 @@ export default function WelcomeCarousel() {
           <AnimatePresence mode="wait">
             <motion.div
               key={index}
-              initial={{ opacity: 0, x: 50 }}
+              initial={
+                shouldReduceMotion ? false : { opacity: 0, x: 50 }
+              }
               animate={{ opacity: 1, x: 0 }}
-              exit={{ opacity: 0, x: -50 }}
-              transition={{ duration: 0.3 }}
+              exit={shouldReduceMotion ? {} : { opacity: 0, x: -50 }}
+              transition={{ duration: shouldReduceMotion ? 0 : 0.3 }}
               className="w-full"
-              drag="x"
-              dragConstraints={{ left: 0, right: 0 }}
-              onDragEnd={(_, info) => {
-                if (info.offset.x < -100) {
-                  next();
-                } else if (info.offset.x > 100 && index > 0) {
-                  setIndex(index - 1);
-                }
-              }}
+              drag={shouldReduceMotion ? false : 'x'}
+              dragConstraints={shouldReduceMotion ? undefined : { left: 0, right: 0 }}
+              onDragEnd={
+                shouldReduceMotion
+                  ? undefined
+                  : (_, info) => {
+                      if (info.offset.x < -100) {
+                        next();
+                      } else if (info.offset.x > 100 && index > 0) {
+                        setIndex(index - 1);
+                      }
+                    }
+              }
             >
               <div className="text-8xl mb-4" aria-hidden="true">
                 {slides[index].icon}

--- a/src/pages/Analytics.tsx
+++ b/src/pages/Analytics.tsx
@@ -17,7 +17,7 @@ export default function Analytics() {
       {!trialStarted && (
         <button
           onClick={openPremium}
-          className="mt-4 px-4 py-2 bg-primary text-white rounded"
+          className="mt-4 px-4 py-2 bg-primary-dark text-white rounded"
         >
           See your 60-day trend
         </button>

--- a/src/pages/Calendar.tsx
+++ b/src/pages/Calendar.tsx
@@ -33,7 +33,7 @@ function DayDetailModal({ date, entry, onClose }: DayDetailModalProps) {
         )}
         <button
           onClick={onClose}
-          className="mt-4 px-4 py-2 bg-primary text-white rounded"
+          className="mt-4 px-4 py-2 bg-primary-dark text-white rounded"
         >
           Close
         </button>
@@ -102,7 +102,7 @@ export default function Calendar() {
             <button
               key={key}
               onClick={() => setSelected(day)}
-              className={`h-16 border rounded flex flex-col items-center justify-center ${!inMonth ? 'text-mutedBlueGray' : ''}`}
+              className={`h-16 border rounded flex flex-col items-center justify-center ${!inMonth ? 'text-primary-dark dark:text-mutedBlueGray' : ''}`}
             >
               <span>{format(day, 'd')}</span>
               {entry && (

--- a/src/pages/Challenge.tsx
+++ b/src/pages/Challenge.tsx
@@ -1,7 +1,9 @@
-import { motion } from 'framer-motion'
+import { motion, useReducedMotion } from 'framer-motion'
 import { useChallengeStore } from '../contexts/useChallengeStore'
 
 function Confetti() {
+  const shouldReduceMotion = useReducedMotion()
+  if (shouldReduceMotion) return null
   const colors = ['#FFD761', '#3b82f6', '#E5F0FB']
   const pieces = Array.from({ length: 25 }, (_, i) => i)
   return (
@@ -33,7 +35,13 @@ export default function Challenge() {
   return (
     <div className="p-4 space-y-4">
       <h1 className="text-2xl font-bold">30 Day Challenge</h1>
-      <div className="h-4 bg-mutedBlueGray rounded-full overflow-hidden">
+      <div
+        className="h-4 bg-mutedBlueGray rounded-full overflow-hidden"
+        role="progressbar"
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-valuenow={Math.round(progress)}
+      >
         <div
           className="h-full bg-gradient-to-r from-primary to-yellow"
           style={{ width: `${progress}%` }}
@@ -47,7 +55,7 @@ export default function Challenge() {
         ))}
       </ul>
       {!joined && (
-        <button onClick={join} className="px-4 py-2 bg-primary text-white rounded">
+        <button onClick={join} className="px-4 py-2 bg-primary-dark text-white rounded">
           Join Challenge
         </button>
       )}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,10 +1,16 @@
-import { motion } from 'framer-motion';
+import { motion, useReducedMotion } from 'framer-motion';
 import StreakCounter from '../components/StreakCounter';
 import ContentFeed from '../components/ContentFeed';
 
 export default function Home() {
+  const shouldReduceMotion = useReducedMotion();
   return (
-    <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="p-4">
+    <motion.div
+      initial={shouldReduceMotion ? false : { opacity: 0 }}
+      animate={{ opacity: 1 }}
+      transition={{ duration: shouldReduceMotion ? 0 : 0.5 }}
+      className="p-4"
+    >
       <h1 className="text-2xl font-bold">Home Page</h1>
       <p className="mt-2">Welcome to the app.</p>
       <StreakCounter />

--- a/src/pages/MoodEntry.tsx
+++ b/src/pages/MoodEntry.tsx
@@ -59,7 +59,7 @@ export default function MoodEntry() {
 
       <button
         onClick={handleSave}
-        className="px-4 py-2 bg-primary text-white rounded"
+        className="px-4 py-2 bg-primary-dark text-white rounded"
       >
         Save Entry
       </button>

--- a/src/pages/TherapyScheduler.tsx
+++ b/src/pages/TherapyScheduler.tsx
@@ -62,7 +62,7 @@ export default function TherapyScheduler() {
           onChange={(e) => setNewTime(e.target.value)}
           className="border p-2 rounded text-indigo dark:text-creamWhite"
         />
-        <button onClick={handleAdd} className="px-4 py-2 bg-primary text-white rounded">
+        <button onClick={handleAdd} className="px-4 py-2 bg-primary-dark text-white rounded">
           Add
         </button>
       </div>

--- a/src/pages/TipOfTheDay.tsx
+++ b/src/pages/TipOfTheDay.tsx
@@ -64,7 +64,7 @@ export default function TipOfTheDay() {
       <div className="flex items-center gap-2">
         <button
           onClick={() => navigate(-1)}
-          className="px-4 py-2 bg-primary text-white rounded"
+          className="px-4 py-2 bg-primary-dark text-white rounded"
         >
           Got it
         </button>


### PR DESCRIPTION
## Summary
- verify color contrast with a new script
- add aria-labels for navigation links and progress bar
- respect prefers-reduced-motion across animated components
- adjust out-of-month calendar text color
- use darker primary shade for buttons for better contrast

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68524fb521c0832f94a0530989b609ee