### PR TITLE
Apply UI feedback

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -133,7 +133,7 @@ function InnerApp() {
   return (
     <div
       className={`min-h-screen ${
-        dark ? 'dark bg-indigo text-creamWhite' : `${colors.bg} text-indigo`
+        dark ? 'dark bg-indigo text-creamWhite' : 'bg-pastelYellow text-indigo'
       }`}
       style={{ backgroundImage: `url(${colors.image})`, backgroundSize: 'cover' }}
     >

--- a/src/index.css
+++ b/src/index.css
@@ -4,6 +4,6 @@
 
 @layer base {
   body {
-    @apply font-nunito;
+    @apply font-nunito bg-pastelYellow text-indigo dark:bg-indigo dark:text-creamWhite;
   }
 }

--- a/src/pages/Analytics.tsx
+++ b/src/pages/Analytics.tsx
@@ -11,9 +11,11 @@ export default function Analytics() {
   const closePremium = () => setShowPremium(false)
 
   return (
-    <div className="p-4">
-      <h1 className="text-2xl font-bold mb-4">Analytics</h1>
-      <MoodAnalytics />
+    <div className="p-4 space-y-4">
+      <h1 className="text-2xl font-bold">Analytics</h1>
+      <div className="bg-white dark:bg-indigo p-4 rounded shadow">
+        <MoodAnalytics />
+      </div>
       {!trialStarted && (
         <button
           onClick={openPremium}

--- a/src/pages/Calendar.tsx
+++ b/src/pages/Calendar.tsx
@@ -78,6 +78,7 @@ export default function Calendar() {
   for (let d = start; d <= end; d = addDays(d, 1)) {
     days.push(d);
   }
+  const today = new Date();
 
   return (
     <div className="p-4">
@@ -98,11 +99,12 @@ export default function Calendar() {
           const key = format(day, 'yyyy-MM-dd');
           const entry = entryMap[key];
           const inMonth = isSameMonth(day, currentMonth);
+          const isToday = day.toDateString() === today.toDateString();
           return (
             <button
               key={key}
               onClick={() => setSelected(day)}
-              className={`h-16 border rounded flex flex-col items-center justify-center ${!inMonth ? 'text-primary-dark dark:text-mutedBlueGray' : ''}`}
+              className={`h-16 border rounded flex flex-col items-center justify-center ${!inMonth ? 'text-primary-dark dark:text-mutedBlueGray' : ''} ${isToday ? 'ring-2 ring-primary-dark' : ''}`}
             >
               <span>{format(day, 'd')}</span>
               {entry && (

--- a/src/pages/Challenge.tsx
+++ b/src/pages/Challenge.tsx
@@ -49,11 +49,20 @@ export default function Challenge() {
       </div>
       <ul className="space-y-1">
         {steps.map((s, i) => (
-          <li key={s} className={i < current ? 'line-through' : ''}>
-            {s}
+          <li key={s} className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              checked={i < current}
+              readOnly
+              className="accent-primary-dark"
+            />
+            <span className={i < current ? 'text-mutedBlueGray line-through' : ''}>
+              {s}
+            </span>
           </li>
         ))}
       </ul>
+      <p className="font-semibold">{Math.round(progress)}% complete</p>
       {!joined && (
         <button onClick={join} className="px-4 py-2 bg-primary-dark text-white rounded">
           Join Challenge

--- a/src/pages/Customize.tsx
+++ b/src/pages/Customize.tsx
@@ -28,7 +28,7 @@ export default function Customize() {
 
       <div>
         <label htmlFor="season-select" className="block mb-1">
-          Seasonal Preference
+          Your season right now?
         </label>
         <select
           id="season-select"
@@ -45,7 +45,7 @@ export default function Customize() {
 
       <div>
         <label htmlFor="notification-range" className="block mb-1">
-          Notification Frequency: {notificationFrequency}
+          Notification Frequency
         </label>
         <input
           id="notification-range"
@@ -56,6 +56,11 @@ export default function Customize() {
           onChange={(e) => setNotificationFrequency(Number(e.target.value))}
           className="w-full"
         />
+        <div className="flex justify-between text-sm text-mutedBlueGray mt-1">
+          <span>Low</span>
+          <span>Medium</span>
+          <span>High</span>
+        </div>
       </div>
 
       <div>
@@ -69,6 +74,9 @@ export default function Customize() {
           onChange={(e) => setReminderTime(e.target.value)}
           className="p-2 border rounded text-indigo dark:text-creamWhite"
         />
+        <p className="mt-1 text-sm text-mutedBlueGray">
+          You’ll be reminded daily at {reminderTime}
+        </p>
       </div>
     </div>
   );

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,6 +1,7 @@
 import { motion, useReducedMotion } from 'framer-motion';
 import StreakCounter from '../components/StreakCounter';
 import ContentFeed from '../components/ContentFeed';
+import { Link } from 'react-router-dom';
 
 export default function Home() {
   const shouldReduceMotion = useReducedMotion();
@@ -12,8 +13,14 @@ export default function Home() {
       className="p-4"
     >
       <h1 className="text-2xl font-bold">Home Page</h1>
-      <p className="mt-2">Welcome to the app.</p>
+      <p className="mt-2">Welcome to the app. "Every day is a new beginning."</p>
       <StreakCounter />
+      <Link
+        to="/mood"
+        className="mt-4 inline-block px-4 py-2 bg-primary-dark text-white rounded"
+      >
+        Log today’s mood
+      </Link>
       <div className="mt-4">
         <ContentFeed />
       </div>

--- a/src/pages/MoodEntry.tsx
+++ b/src/pages/MoodEntry.tsx
@@ -10,10 +10,15 @@ export default function MoodEntry() {
   const { addEntry } = useMoodStore();
   const [mood, setMood] = useState(3);
   const [notes, setNotes] = useState('');
+  const [rows, setRows] = useState(1);
+  const [saved, setSaved] = useState(false);
 
   const handleSave = () => {
     addEntry({ mood, notes });
     setNotes('');
+    setRows(1);
+    setSaved(true);
+    setTimeout(() => setSaved(false), 2000);
   };
 
   useEffect(() => {
@@ -33,7 +38,7 @@ export default function MoodEntry() {
               onClick={() => setMood(index + 1)}
               aria-label={moodLabels[index]}
               className={
-                'w-12 h-12 flex items-center justify-center rounded-full border text-3xl transition transform focus:outline-none focus:ring-2 focus:ring-primary ' +
+                'w-12 h-12 flex items-center justify-center rounded-full border text-3xl transition transform focus:outline-none focus:ring-2 focus:ring-primary hover:scale-110 ' +
                 (mood === index + 1 ? 'scale-110' : 'opacity-50')
               }
             >
@@ -51,9 +56,13 @@ export default function MoodEntry() {
         <textarea
           id="notes"
           value={notes}
+          onFocus={() => setRows(4)}
+          onBlur={() => {
+            if (notes === '') setRows(1);
+          }}
           onChange={(e) => setNotes(e.target.value)}
-          className="w-full p-2 border rounded bg-creamWhite text-indigo dark:text-creamWhite"
-          rows={4}
+          className="w-full p-2 border rounded bg-creamWhite text-indigo dark:text-creamWhite transition-all"
+          rows={rows}
         />
       </div>
 
@@ -63,6 +72,11 @@ export default function MoodEntry() {
       >
         Save Entry
       </button>
+      {saved && (
+        <div className="mt-2 p-2 bg-paleSky text-indigo rounded shadow">
+          Entry saved!
+        </div>
+      )}
     </div>
   );
 }

--- a/src/pages/__snapshots__/MoodEntry.a11y.test.tsx.snap
+++ b/src/pages/__snapshots__/MoodEntry.a11y.test.tsx.snap
@@ -1217,7 +1217,7 @@ exports[`MoodEntry accessibility > has no accessibility violations 1`] = `
             },
           ],
           "any": [],
-          "html": "<button aria-label="Very sad" class="w-12 h-12 flex items-center justify-center rounded-full border text-3xl transition transform focus:outline-none focus:ring-2 focus:ring-primary opacity-50">😢</button>",
+          "html": "<button aria-label="Very sad" class="w-12 h-12 flex items-center justify-center rounded-full border text-3xl transition transform focus:outline-none focus:ring-2 focus:ring-primary hover:scale-110 opacity-50">😢</button>",
           "impact": null,
           "none": [
             CheckResult {
@@ -1243,7 +1243,7 @@ exports[`MoodEntry accessibility > has no accessibility violations 1`] = `
             },
           ],
           "any": [],
-          "html": "<button aria-label="Sad" class="w-12 h-12 flex items-center justify-center rounded-full border text-3xl transition transform focus:outline-none focus:ring-2 focus:ring-primary opacity-50">🙁</button>",
+          "html": "<button aria-label="Sad" class="w-12 h-12 flex items-center justify-center rounded-full border text-3xl transition transform focus:outline-none focus:ring-2 focus:ring-primary hover:scale-110 opacity-50">🙁</button>",
           "impact": null,
           "none": [
             CheckResult {
@@ -1269,7 +1269,7 @@ exports[`MoodEntry accessibility > has no accessibility violations 1`] = `
             },
           ],
           "any": [],
-          "html": "<button aria-label="Neutral" class="w-12 h-12 flex items-center justify-center rounded-full border text-3xl transition transform focus:outline-none focus:ring-2 focus:ring-primary scale-110">😐</button>",
+          "html": "<button aria-label="Neutral" class="w-12 h-12 flex items-center justify-center rounded-full border text-3xl transition transform focus:outline-none focus:ring-2 focus:ring-primary hover:scale-110 scale-110">😐</button>",
           "impact": null,
           "none": [
             CheckResult {
@@ -1295,7 +1295,7 @@ exports[`MoodEntry accessibility > has no accessibility violations 1`] = `
             },
           ],
           "any": [],
-          "html": "<button aria-label="Happy" class="w-12 h-12 flex items-center justify-center rounded-full border text-3xl transition transform focus:outline-none focus:ring-2 focus:ring-primary opacity-50">🙂</button>",
+          "html": "<button aria-label="Happy" class="w-12 h-12 flex items-center justify-center rounded-full border text-3xl transition transform focus:outline-none focus:ring-2 focus:ring-primary hover:scale-110 opacity-50">🙂</button>",
           "impact": null,
           "none": [
             CheckResult {
@@ -1321,7 +1321,7 @@ exports[`MoodEntry accessibility > has no accessibility violations 1`] = `
             },
           ],
           "any": [],
-          "html": "<button aria-label="Very happy" class="w-12 h-12 flex items-center justify-center rounded-full border text-3xl transition transform focus:outline-none focus:ring-2 focus:ring-primary opacity-50">😄</button>",
+          "html": "<button aria-label="Very happy" class="w-12 h-12 flex items-center justify-center rounded-full border text-3xl transition transform focus:outline-none focus:ring-2 focus:ring-primary hover:scale-110 opacity-50">😄</button>",
           "impact": null,
           "none": [
             CheckResult {
@@ -1363,7 +1363,7 @@ exports[`MoodEntry accessibility > has no accessibility violations 1`] = `
             },
           ],
           "any": [],
-          "html": "<button aria-label="Very sad" class="w-12 h-12 flex items-center justify-center rounded-full border text-3xl transition transform focus:outline-none focus:ring-2 focus:ring-primary opacity-50">😢</button>",
+          "html": "<button aria-label="Very sad" class="w-12 h-12 flex items-center justify-center rounded-full border text-3xl transition transform focus:outline-none focus:ring-2 focus:ring-primary hover:scale-110 opacity-50">😢</button>",
           "impact": null,
           "none": [],
           "target": [
@@ -1381,7 +1381,7 @@ exports[`MoodEntry accessibility > has no accessibility violations 1`] = `
             },
           ],
           "any": [],
-          "html": "<button aria-label="Sad" class="w-12 h-12 flex items-center justify-center rounded-full border text-3xl transition transform focus:outline-none focus:ring-2 focus:ring-primary opacity-50">🙁</button>",
+          "html": "<button aria-label="Sad" class="w-12 h-12 flex items-center justify-center rounded-full border text-3xl transition transform focus:outline-none focus:ring-2 focus:ring-primary hover:scale-110 opacity-50">🙁</button>",
           "impact": null,
           "none": [],
           "target": [
@@ -1399,7 +1399,7 @@ exports[`MoodEntry accessibility > has no accessibility violations 1`] = `
             },
           ],
           "any": [],
-          "html": "<button aria-label="Neutral" class="w-12 h-12 flex items-center justify-center rounded-full border text-3xl transition transform focus:outline-none focus:ring-2 focus:ring-primary scale-110">😐</button>",
+          "html": "<button aria-label="Neutral" class="w-12 h-12 flex items-center justify-center rounded-full border text-3xl transition transform focus:outline-none focus:ring-2 focus:ring-primary hover:scale-110 scale-110">😐</button>",
           "impact": null,
           "none": [],
           "target": [
@@ -1417,7 +1417,7 @@ exports[`MoodEntry accessibility > has no accessibility violations 1`] = `
             },
           ],
           "any": [],
-          "html": "<button aria-label="Happy" class="w-12 h-12 flex items-center justify-center rounded-full border text-3xl transition transform focus:outline-none focus:ring-2 focus:ring-primary opacity-50">🙂</button>",
+          "html": "<button aria-label="Happy" class="w-12 h-12 flex items-center justify-center rounded-full border text-3xl transition transform focus:outline-none focus:ring-2 focus:ring-primary hover:scale-110 opacity-50">🙂</button>",
           "impact": null,
           "none": [],
           "target": [
@@ -1435,7 +1435,7 @@ exports[`MoodEntry accessibility > has no accessibility violations 1`] = `
             },
           ],
           "any": [],
-          "html": "<button aria-label="Very happy" class="w-12 h-12 flex items-center justify-center rounded-full border text-3xl transition transform focus:outline-none focus:ring-2 focus:ring-primary opacity-50">😄</button>",
+          "html": "<button aria-label="Very happy" class="w-12 h-12 flex items-center justify-center rounded-full border text-3xl transition transform focus:outline-none focus:ring-2 focus:ring-primary hover:scale-110 opacity-50">😄</button>",
           "impact": null,
           "none": [],
           "target": [
@@ -1461,7 +1461,7 @@ exports[`MoodEntry accessibility > has no accessibility violations 1`] = `
         {
           "all": [],
           "any": [],
-          "html": "<button aria-label="Very sad" class="w-12 h-12 flex items-center justify-center rounded-full border text-3xl transition transform focus:outline-none focus:ring-2 focus:ring-primary opacity-50">😢</button>",
+          "html": "<button aria-label="Very sad" class="w-12 h-12 flex items-center justify-center rounded-full border text-3xl transition transform focus:outline-none focus:ring-2 focus:ring-primary hover:scale-110 opacity-50">😢</button>",
           "impact": null,
           "none": [
             CheckResult {
@@ -1479,7 +1479,7 @@ exports[`MoodEntry accessibility > has no accessibility violations 1`] = `
         {
           "all": [],
           "any": [],
-          "html": "<button aria-label="Sad" class="w-12 h-12 flex items-center justify-center rounded-full border text-3xl transition transform focus:outline-none focus:ring-2 focus:ring-primary opacity-50">🙁</button>",
+          "html": "<button aria-label="Sad" class="w-12 h-12 flex items-center justify-center rounded-full border text-3xl transition transform focus:outline-none focus:ring-2 focus:ring-primary hover:scale-110 opacity-50">🙁</button>",
           "impact": null,
           "none": [
             CheckResult {
@@ -1497,7 +1497,7 @@ exports[`MoodEntry accessibility > has no accessibility violations 1`] = `
         {
           "all": [],
           "any": [],
-          "html": "<button aria-label="Neutral" class="w-12 h-12 flex items-center justify-center rounded-full border text-3xl transition transform focus:outline-none focus:ring-2 focus:ring-primary scale-110">😐</button>",
+          "html": "<button aria-label="Neutral" class="w-12 h-12 flex items-center justify-center rounded-full border text-3xl transition transform focus:outline-none focus:ring-2 focus:ring-primary hover:scale-110 scale-110">😐</button>",
           "impact": null,
           "none": [
             CheckResult {
@@ -1515,7 +1515,7 @@ exports[`MoodEntry accessibility > has no accessibility violations 1`] = `
         {
           "all": [],
           "any": [],
-          "html": "<button aria-label="Happy" class="w-12 h-12 flex items-center justify-center rounded-full border text-3xl transition transform focus:outline-none focus:ring-2 focus:ring-primary opacity-50">🙂</button>",
+          "html": "<button aria-label="Happy" class="w-12 h-12 flex items-center justify-center rounded-full border text-3xl transition transform focus:outline-none focus:ring-2 focus:ring-primary hover:scale-110 opacity-50">🙂</button>",
           "impact": null,
           "none": [
             CheckResult {
@@ -1533,7 +1533,7 @@ exports[`MoodEntry accessibility > has no accessibility violations 1`] = `
         {
           "all": [],
           "any": [],
-          "html": "<button aria-label="Very happy" class="w-12 h-12 flex items-center justify-center rounded-full border text-3xl transition transform focus:outline-none focus:ring-2 focus:ring-primary opacity-50">😄</button>",
+          "html": "<button aria-label="Very happy" class="w-12 h-12 flex items-center justify-center rounded-full border text-3xl transition transform focus:outline-none focus:ring-2 focus:ring-primary hover:scale-110 opacity-50">😄</button>",
           "impact": null,
           "none": [
             CheckResult {
@@ -1589,7 +1589,7 @@ exports[`MoodEntry accessibility > has no accessibility violations 1`] = `
             },
           ],
           "any": [],
-          "html": "<button aria-label="Very sad" class="w-12 h-12 flex items-center justify-center rounded-full border text-3xl transition transform focus:outline-none focus:ring-2 focus:ring-primary opacity-50">😢</button>",
+          "html": "<button aria-label="Very sad" class="w-12 h-12 flex items-center justify-center rounded-full border text-3xl transition transform focus:outline-none focus:ring-2 focus:ring-primary hover:scale-110 opacity-50">😢</button>",
           "impact": null,
           "none": [],
           "target": [
@@ -1621,7 +1621,7 @@ exports[`MoodEntry accessibility > has no accessibility violations 1`] = `
             },
           ],
           "any": [],
-          "html": "<button aria-label="Sad" class="w-12 h-12 flex items-center justify-center rounded-full border text-3xl transition transform focus:outline-none focus:ring-2 focus:ring-primary opacity-50">🙁</button>",
+          "html": "<button aria-label="Sad" class="w-12 h-12 flex items-center justify-center rounded-full border text-3xl transition transform focus:outline-none focus:ring-2 focus:ring-primary hover:scale-110 opacity-50">🙁</button>",
           "impact": null,
           "none": [],
           "target": [
@@ -1653,7 +1653,7 @@ exports[`MoodEntry accessibility > has no accessibility violations 1`] = `
             },
           ],
           "any": [],
-          "html": "<button aria-label="Neutral" class="w-12 h-12 flex items-center justify-center rounded-full border text-3xl transition transform focus:outline-none focus:ring-2 focus:ring-primary scale-110">😐</button>",
+          "html": "<button aria-label="Neutral" class="w-12 h-12 flex items-center justify-center rounded-full border text-3xl transition transform focus:outline-none focus:ring-2 focus:ring-primary hover:scale-110 scale-110">😐</button>",
           "impact": null,
           "none": [],
           "target": [
@@ -1685,7 +1685,7 @@ exports[`MoodEntry accessibility > has no accessibility violations 1`] = `
             },
           ],
           "any": [],
-          "html": "<button aria-label="Happy" class="w-12 h-12 flex items-center justify-center rounded-full border text-3xl transition transform focus:outline-none focus:ring-2 focus:ring-primary opacity-50">🙂</button>",
+          "html": "<button aria-label="Happy" class="w-12 h-12 flex items-center justify-center rounded-full border text-3xl transition transform focus:outline-none focus:ring-2 focus:ring-primary hover:scale-110 opacity-50">🙂</button>",
           "impact": null,
           "none": [],
           "target": [
@@ -1717,7 +1717,7 @@ exports[`MoodEntry accessibility > has no accessibility violations 1`] = `
             },
           ],
           "any": [],
-          "html": "<button aria-label="Very happy" class="w-12 h-12 flex items-center justify-center rounded-full border text-3xl transition transform focus:outline-none focus:ring-2 focus:ring-primary opacity-50">😄</button>",
+          "html": "<button aria-label="Very happy" class="w-12 h-12 flex items-center justify-center rounded-full border text-3xl transition transform focus:outline-none focus:ring-2 focus:ring-primary hover:scale-110 opacity-50">😄</button>",
           "impact": null,
           "none": [],
           "target": [
@@ -1751,7 +1751,7 @@ exports[`MoodEntry accessibility > has no accessibility violations 1`] = `
               "relatedNodes": [],
             },
           ],
-          "html": "<button aria-label="Very sad" class="w-12 h-12 flex items-center justify-center rounded-full border text-3xl transition transform focus:outline-none focus:ring-2 focus:ring-primary opacity-50">😢</button>",
+          "html": "<button aria-label="Very sad" class="w-12 h-12 flex items-center justify-center rounded-full border text-3xl transition transform focus:outline-none focus:ring-2 focus:ring-primary hover:scale-110 opacity-50">😢</button>",
           "impact": null,
           "none": [],
           "target": [
@@ -1769,7 +1769,7 @@ exports[`MoodEntry accessibility > has no accessibility violations 1`] = `
               "relatedNodes": [],
             },
           ],
-          "html": "<button aria-label="Sad" class="w-12 h-12 flex items-center justify-center rounded-full border text-3xl transition transform focus:outline-none focus:ring-2 focus:ring-primary opacity-50">🙁</button>",
+          "html": "<button aria-label="Sad" class="w-12 h-12 flex items-center justify-center rounded-full border text-3xl transition transform focus:outline-none focus:ring-2 focus:ring-primary hover:scale-110 opacity-50">🙁</button>",
           "impact": null,
           "none": [],
           "target": [
@@ -1787,7 +1787,7 @@ exports[`MoodEntry accessibility > has no accessibility violations 1`] = `
               "relatedNodes": [],
             },
           ],
-          "html": "<button aria-label="Neutral" class="w-12 h-12 flex items-center justify-center rounded-full border text-3xl transition transform focus:outline-none focus:ring-2 focus:ring-primary scale-110">😐</button>",
+          "html": "<button aria-label="Neutral" class="w-12 h-12 flex items-center justify-center rounded-full border text-3xl transition transform focus:outline-none focus:ring-2 focus:ring-primary hover:scale-110 scale-110">😐</button>",
           "impact": null,
           "none": [],
           "target": [
@@ -1805,7 +1805,7 @@ exports[`MoodEntry accessibility > has no accessibility violations 1`] = `
               "relatedNodes": [],
             },
           ],
-          "html": "<button aria-label="Happy" class="w-12 h-12 flex items-center justify-center rounded-full border text-3xl transition transform focus:outline-none focus:ring-2 focus:ring-primary opacity-50">🙂</button>",
+          "html": "<button aria-label="Happy" class="w-12 h-12 flex items-center justify-center rounded-full border text-3xl transition transform focus:outline-none focus:ring-2 focus:ring-primary hover:scale-110 opacity-50">🙂</button>",
           "impact": null,
           "none": [],
           "target": [
@@ -1823,7 +1823,7 @@ exports[`MoodEntry accessibility > has no accessibility violations 1`] = `
               "relatedNodes": [],
             },
           ],
-          "html": "<button aria-label="Very happy" class="w-12 h-12 flex items-center justify-center rounded-full border text-3xl transition transform focus:outline-none focus:ring-2 focus:ring-primary opacity-50">😄</button>",
+          "html": "<button aria-label="Very happy" class="w-12 h-12 flex items-center justify-center rounded-full border text-3xl transition transform focus:outline-none focus:ring-2 focus:ring-primary hover:scale-110 opacity-50">😄</button>",
           "impact": null,
           "none": [],
           "target": [
@@ -1864,7 +1864,7 @@ exports[`MoodEntry accessibility > has no accessibility violations 1`] = `
               "relatedNodes": [],
             },
           ],
-          "html": "<button aria-label="Very sad" class="w-12 h-12 flex items-center justify-center rounded-full border text-3xl transition transform focus:outline-none focus:ring-2 focus:ring-primary opacity-50">😢</button>",
+          "html": "<button aria-label="Very sad" class="w-12 h-12 flex items-center justify-center rounded-full border text-3xl transition transform focus:outline-none focus:ring-2 focus:ring-primary hover:scale-110 opacity-50">😢</button>",
           "impact": null,
           "none": [],
           "target": [
@@ -1889,7 +1889,7 @@ exports[`MoodEntry accessibility > has no accessibility violations 1`] = `
               "relatedNodes": [],
             },
           ],
-          "html": "<button aria-label="Sad" class="w-12 h-12 flex items-center justify-center rounded-full border text-3xl transition transform focus:outline-none focus:ring-2 focus:ring-primary opacity-50">🙁</button>",
+          "html": "<button aria-label="Sad" class="w-12 h-12 flex items-center justify-center rounded-full border text-3xl transition transform focus:outline-none focus:ring-2 focus:ring-primary hover:scale-110 opacity-50">🙁</button>",
           "impact": null,
           "none": [],
           "target": [
@@ -1914,7 +1914,7 @@ exports[`MoodEntry accessibility > has no accessibility violations 1`] = `
               "relatedNodes": [],
             },
           ],
-          "html": "<button aria-label="Neutral" class="w-12 h-12 flex items-center justify-center rounded-full border text-3xl transition transform focus:outline-none focus:ring-2 focus:ring-primary scale-110">😐</button>",
+          "html": "<button aria-label="Neutral" class="w-12 h-12 flex items-center justify-center rounded-full border text-3xl transition transform focus:outline-none focus:ring-2 focus:ring-primary hover:scale-110 scale-110">😐</button>",
           "impact": null,
           "none": [],
           "target": [
@@ -1939,7 +1939,7 @@ exports[`MoodEntry accessibility > has no accessibility violations 1`] = `
               "relatedNodes": [],
             },
           ],
-          "html": "<button aria-label="Happy" class="w-12 h-12 flex items-center justify-center rounded-full border text-3xl transition transform focus:outline-none focus:ring-2 focus:ring-primary opacity-50">🙂</button>",
+          "html": "<button aria-label="Happy" class="w-12 h-12 flex items-center justify-center rounded-full border text-3xl transition transform focus:outline-none focus:ring-2 focus:ring-primary hover:scale-110 opacity-50">🙂</button>",
           "impact": null,
           "none": [],
           "target": [
@@ -1964,7 +1964,7 @@ exports[`MoodEntry accessibility > has no accessibility violations 1`] = `
               "relatedNodes": [],
             },
           ],
-          "html": "<button aria-label="Very happy" class="w-12 h-12 flex items-center justify-center rounded-full border text-3xl transition transform focus:outline-none focus:ring-2 focus:ring-primary opacity-50">😄</button>",
+          "html": "<button aria-label="Very happy" class="w-12 h-12 flex items-center justify-center rounded-full border text-3xl transition transform focus:outline-none focus:ring-2 focus:ring-primary hover:scale-110 opacity-50">😄</button>",
           "impact": null,
           "none": [],
           "target": [
@@ -2021,7 +2021,7 @@ exports[`MoodEntry accessibility > has no accessibility violations 1`] = `
               "relatedNodes": [],
             },
           ],
-          "html": "<textarea id="notes" class="w-full p-2 border rounded bg-creamWhite text-indigo dark:text-creamWhite" rows="4"></textarea>",
+          "html": "<textarea id="notes" class="w-full p-2 border rounded bg-creamWhite text-indigo dark:text-creamWhite transition-all" rows="1"></textarea>",
           "impact": null,
           "none": [],
           "target": [
@@ -2078,7 +2078,7 @@ exports[`MoodEntry accessibility > has no accessibility violations 1`] = `
         {
           "all": [],
           "any": [],
-          "html": "<textarea id="notes" class="w-full p-2 border rounded bg-creamWhite text-indigo dark:text-creamWhite" rows="4"></textarea>",
+          "html": "<textarea id="notes" class="w-full p-2 border rounded bg-creamWhite text-indigo dark:text-creamWhite transition-all" rows="1"></textarea>",
           "impact": null,
           "none": [
             CheckResult {
@@ -2161,7 +2161,7 @@ exports[`MoodEntry accessibility > has no accessibility violations 1`] = `
         {
           "all": [],
           "any": [],
-          "html": "<textarea id="notes" class="w-full p-2 border rounded bg-creamWhite text-indigo dark:text-creamWhite" rows="4"></textarea>",
+          "html": "<textarea id="notes" class="w-full p-2 border rounded bg-creamWhite text-indigo dark:text-creamWhite transition-all" rows="1"></textarea>",
           "impact": null,
           "none": [
             CheckResult {
@@ -2209,7 +2209,7 @@ exports[`MoodEntry accessibility > has no accessibility violations 1`] = `
               ],
             },
           ],
-          "html": "<textarea id="notes" class="w-full p-2 border rounded bg-creamWhite text-indigo dark:text-creamWhite" rows="4"></textarea>",
+          "html": "<textarea id="notes" class="w-full p-2 border rounded bg-creamWhite text-indigo dark:text-creamWhite transition-all" rows="1"></textarea>",
           "impact": null,
           "none": [
             CheckResult {
@@ -2256,7 +2256,7 @@ exports[`MoodEntry accessibility > has no accessibility violations 1`] = `
               "relatedNodes": [],
             },
           ],
-          "html": "<button aria-label="Very sad" class="w-12 h-12 flex items-center justify-center rounded-full border text-3xl transition transform focus:outline-none focus:ring-2 focus:ring-primary opacity-50">😢</button>",
+          "html": "<button aria-label="Very sad" class="w-12 h-12 flex items-center justify-center rounded-full border text-3xl transition transform focus:outline-none focus:ring-2 focus:ring-primary hover:scale-110 opacity-50">😢</button>",
           "impact": null,
           "none": [],
           "target": [
@@ -2274,7 +2274,7 @@ exports[`MoodEntry accessibility > has no accessibility violations 1`] = `
               "relatedNodes": [],
             },
           ],
-          "html": "<button aria-label="Sad" class="w-12 h-12 flex items-center justify-center rounded-full border text-3xl transition transform focus:outline-none focus:ring-2 focus:ring-primary opacity-50">🙁</button>",
+          "html": "<button aria-label="Sad" class="w-12 h-12 flex items-center justify-center rounded-full border text-3xl transition transform focus:outline-none focus:ring-2 focus:ring-primary hover:scale-110 opacity-50">🙁</button>",
           "impact": null,
           "none": [],
           "target": [
@@ -2292,7 +2292,7 @@ exports[`MoodEntry accessibility > has no accessibility violations 1`] = `
               "relatedNodes": [],
             },
           ],
-          "html": "<button aria-label="Neutral" class="w-12 h-12 flex items-center justify-center rounded-full border text-3xl transition transform focus:outline-none focus:ring-2 focus:ring-primary scale-110">😐</button>",
+          "html": "<button aria-label="Neutral" class="w-12 h-12 flex items-center justify-center rounded-full border text-3xl transition transform focus:outline-none focus:ring-2 focus:ring-primary hover:scale-110 scale-110">😐</button>",
           "impact": null,
           "none": [],
           "target": [
@@ -2310,7 +2310,7 @@ exports[`MoodEntry accessibility > has no accessibility violations 1`] = `
               "relatedNodes": [],
             },
           ],
-          "html": "<button aria-label="Happy" class="w-12 h-12 flex items-center justify-center rounded-full border text-3xl transition transform focus:outline-none focus:ring-2 focus:ring-primary opacity-50">🙂</button>",
+          "html": "<button aria-label="Happy" class="w-12 h-12 flex items-center justify-center rounded-full border text-3xl transition transform focus:outline-none focus:ring-2 focus:ring-primary hover:scale-110 opacity-50">🙂</button>",
           "impact": null,
           "none": [],
           "target": [
@@ -2328,7 +2328,7 @@ exports[`MoodEntry accessibility > has no accessibility violations 1`] = `
               "relatedNodes": [],
             },
           ],
-          "html": "<button aria-label="Very happy" class="w-12 h-12 flex items-center justify-center rounded-full border text-3xl transition transform focus:outline-none focus:ring-2 focus:ring-primary opacity-50">😄</button>",
+          "html": "<button aria-label="Very happy" class="w-12 h-12 flex items-center justify-center rounded-full border text-3xl transition transform focus:outline-none focus:ring-2 focus:ring-primary hover:scale-110 opacity-50">😄</button>",
           "impact": null,
           "none": [],
           "target": [

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -14,6 +14,7 @@ module.exports = {
         indigo: '#1D3557',
         creamWhite: '#FFFDF8',
         mutedBlueGray: '#B7C9D4',
+        pastelYellow: '#FFF9E6',
       },
       fontFamily: {
         nunito: ['\'Nunito\'', 'sans-serif'],


### PR DESCRIPTION
## Summary
- lighten site background
- animate mood selection and show save toast
- highlight today on the calendar
- wrap analytics chart in a card
- improve challenge layout with checkboxes and progress
- tweak customize labels and slider
- add quick link on the home page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853382673a4832fa5b253e03b445cc0