### PR TITLE
Add card styling and pastel colors

### DIFF
--- a/src/components/MoodAnalytics.tsx
+++ b/src/components/MoodAnalytics.tsx
@@ -110,7 +110,7 @@ export default function MoodAnalytics() {
         </div>
         <Line data={lineChartData} options={options} />
       </div>
-      <div className="p-4 border rounded">
+      <div className="p-4 border rounded bg-creamWhite dark:bg-indigo">
         <h3 className="font-bold mb-2">Last 7 Days Summary</h3>
         <p>Average Mood: {summary.averageMood.toFixed(2)}</p>
         <p>Highest Mood Day: {summary.highestMoodDay}</p>

--- a/src/components/PremiumModal.tsx
+++ b/src/components/PremiumModal.tsx
@@ -8,7 +8,7 @@ interface PremiumModalProps {
 export default function PremiumModal({ onStart, onClose }: PremiumModalProps) {
   return (
     <div className="fixed inset-0 flex items-center justify-center bg-primary-light bg-opacity-90 z-50 p-4">
-      <div className="bg-white p-6 rounded shadow max-w-sm w-full text-center">
+      <div className="bg-creamWhite dark:bg-indigo p-6 rounded shadow max-w-sm w-full text-center">
         <h2 className="text-xl font-bold mb-2">Unlock Premium Analytics</h2>
         <p className="mb-4">See your 60-day mood trends and more.</p>
         <div className="flex justify-center gap-4">

--- a/src/components/StreakCounter.tsx
+++ b/src/components/StreakCounter.tsx
@@ -9,7 +9,7 @@ export default function StreakCounter() {
   else if (streak >= 7) reward = '🔥';
 
   return (
-    <div className="mt-4 p-4 border rounded">
+    <div className="mt-4 p-4 border rounded bg-creamWhite dark:bg-indigo">
       <h2 className="text-lg font-bold">Current Streak</h2>
       <p className="text-2xl">
         {streak} day{streak === 1 ? '' : 's'} {reward}

--- a/src/index.css
+++ b/src/index.css
@@ -7,3 +7,9 @@
     @apply font-nunito bg-pastelYellow text-indigo dark:bg-indigo dark:text-creamWhite;
   }
 }
+
+@layer components {
+  .card {
+    @apply bg-creamWhite dark:bg-indigo p-4 rounded shadow;
+  }
+}

--- a/src/pages/Analytics.tsx
+++ b/src/pages/Analytics.tsx
@@ -13,7 +13,7 @@ export default function Analytics() {
   return (
     <div className="p-4 space-y-4">
       <h1 className="text-2xl font-bold">Analytics</h1>
-      <div className="bg-white dark:bg-indigo p-4 rounded shadow">
+      <div className="card">
         <MoodAnalytics />
       </div>
       {!trialStarted && (

--- a/src/pages/Calendar.tsx
+++ b/src/pages/Calendar.tsx
@@ -82,20 +82,21 @@ export default function Calendar() {
 
   return (
     <div className="p-4">
-      <div className="flex items-center justify-between mb-4">
-        <button onClick={() => setCurrentMonth(addMonths(currentMonth, -1))} className="px-2">Prev</button>
-        <h2 className="text-xl font-bold">{format(currentMonth, 'MMMM yyyy')}</h2>
-        <button onClick={() => setCurrentMonth(addMonths(currentMonth, 1))} className="px-2">Next</button>
-      </div>
-      <div
-        className="grid grid-cols-7 gap-2 text-center"
-        role="grid"
-        aria-label={`Mood entries for ${format(currentMonth, 'MMMM yyyy')}`}
-      >
-        {['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'].map((d) => (
-          <div key={d} className="font-semibold">{d}</div>
-        ))}
-        {days.map((day) => {
+      <div className="card mb-4">
+        <div className="flex items-center justify-between mb-4">
+          <button onClick={() => setCurrentMonth(addMonths(currentMonth, -1))} className="px-2">Prev</button>
+          <h2 className="text-xl font-bold">{format(currentMonth, 'MMMM yyyy')}</h2>
+          <button onClick={() => setCurrentMonth(addMonths(currentMonth, 1))} className="px-2">Next</button>
+        </div>
+        <div
+          className="grid grid-cols-7 gap-2 text-center"
+          role="grid"
+          aria-label={`Mood entries for ${format(currentMonth, 'MMMM yyyy')}`}
+        >
+          {['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'].map((d) => (
+            <div key={d} className="font-semibold">{d}</div>
+          ))}
+          {days.map((day) => {
           const key = format(day, 'yyyy-MM-dd');
           const entry = entryMap[key];
           const inMonth = isSameMonth(day, currentMonth);
@@ -115,7 +116,8 @@ export default function Calendar() {
               )}
             </button>
           );
-        })}
+          })}
+        </div>
       </div>
       {selected && (
         <DayDetailModal

--- a/src/pages/MoodEntry.tsx
+++ b/src/pages/MoodEntry.tsx
@@ -25,8 +25,8 @@ export default function MoodEntry() {
     setLastPrompt(Date.now());
   }, [setLastPrompt]);
 
-  return (
-    <div className="p-4 space-y-6">
+    return (
+      <div className="p-4 space-y-6 card">
       <h1 className="text-2xl font-bold">Mood Entry</h1>
 
       <div>

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -13,6 +13,10 @@ module.exports = {
         paleSky: '#E5F0FB',
         indigo: '#1D3557',
         creamWhite: '#FFFDF8',
+        card: {
+          DEFAULT: '#FFFDF8',
+          indigo: '#1D3557',
+        },
         mutedBlueGray: '#B7C9D4',
         pastelYellow: '#FFF9E6',
       },


### PR DESCRIPTION
## Summary
- define card color palette in Tailwind config
- add `.card` utility for content panels
- use the card utility in Analytics, Calendar and MoodEntry
- tint StreakCounter, PremiumModal and MoodAnalytics panels

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68533ca1e194832fb939c146ffe87954