### PR TITLE
Add spacing and typography utilities

### DIFF
--- a/src/pages/Calendar.tsx
+++ b/src/pages/Calendar.tsx
@@ -22,14 +22,16 @@ function DayDetailModal({ date, entry, onClose }: DayDetailModalProps) {
   return (
     <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 z-50">
       <div className="bg-creamWhite dark:bg-indigo p-4 rounded shadow max-w-sm w-full">
-        <h2 className="text-lg font-bold mb-2">{format(date, 'PPP')}</h2>
+        <h2 className="text-2xl font-bold mb-2">{format(date, 'PPP')}</h2>
         {entry ? (
           <div className="space-y-1">
-            <p>Mood: {entry.mood}</p>
-            {entry.notes && <p>Notes: {entry.notes}</p>}
+            <p className="text-base leading-relaxed">Mood: {entry.mood}</p>
+            {entry.notes && (
+              <p className="text-base leading-relaxed">Notes: {entry.notes}</p>
+            )}
           </div>
         ) : (
-          <p>No entry for this day.</p>
+          <p className="text-base leading-relaxed">No entry for this day.</p>
         )}
         <button
           onClick={onClose}
@@ -81,11 +83,11 @@ export default function Calendar() {
   const today = new Date();
 
   return (
-    <div className="p-4">
-      <div className="card mb-4">
+    <div className="p-4 space-y-6">
+      <div className="card mb-4 space-y-4">
         <div className="flex items-center justify-between mb-4">
           <button onClick={() => setCurrentMonth(addMonths(currentMonth, -1))} className="px-2">Prev</button>
-          <h2 className="text-xl font-bold">{format(currentMonth, 'MMMM yyyy')}</h2>
+          <h2 className="text-2xl font-bold">{format(currentMonth, 'MMMM yyyy')}</h2>
           <button onClick={() => setCurrentMonth(addMonths(currentMonth, 1))} className="px-2">Next</button>
         </div>
         <div

--- a/src/pages/Customize.tsx
+++ b/src/pages/Customize.tsx
@@ -14,10 +14,10 @@ export default function Customize() {
 
   return (
     <div className="p-4 space-y-6">
-      <h1 className="text-2xl font-bold">Customize Settings</h1>
+      <h1 className="text-2xl font-bold mb-4">Customize Settings</h1>
 
       <div className="flex items-center gap-2">
-        <label htmlFor="dark-toggle">Dark Mode</label>
+        <label htmlFor="dark-toggle" className="text-base leading-relaxed">Dark Mode</label>
         <input
           id="dark-toggle"
           type="checkbox"
@@ -27,7 +27,7 @@ export default function Customize() {
       </div>
 
       <div>
-        <label htmlFor="season-select" className="block mb-1">
+        <label htmlFor="season-select" className="block mb-1 text-base leading-relaxed">
           Your season right now?
         </label>
         <select
@@ -44,7 +44,7 @@ export default function Customize() {
       </div>
 
       <div>
-        <label htmlFor="notification-range" className="block mb-1">
+        <label htmlFor="notification-range" className="block mb-1 text-base leading-relaxed">
           Notification Frequency
         </label>
         <input
@@ -64,7 +64,7 @@ export default function Customize() {
       </div>
 
       <div>
-        <label htmlFor="reminder-time" className="block mb-1">
+        <label htmlFor="reminder-time" className="block mb-1 text-base leading-relaxed">
           Daily Check-In Time
         </label>
         <input
@@ -74,7 +74,7 @@ export default function Customize() {
           onChange={(e) => setReminderTime(e.target.value)}
           className="p-2 border rounded text-indigo dark:text-creamWhite"
         />
-        <p className="mt-1 text-sm text-mutedBlueGray">
+        <p className="mt-1 text-base leading-relaxed text-mutedBlueGray">
           You’ll be reminded daily at {reminderTime}
         </p>
       </div>

--- a/src/pages/MoodEntry.tsx
+++ b/src/pages/MoodEntry.tsx
@@ -25,12 +25,12 @@ export default function MoodEntry() {
     setLastPrompt(Date.now());
   }, [setLastPrompt]);
 
-    return (
+  return (
       <div className="p-4 space-y-6 card">
-      <h1 className="text-2xl font-bold">Mood Entry</h1>
+      <h1 className="text-2xl font-bold mb-4">Mood Entry</h1>
 
       <div>
-        <p className="mb-2">How are you feeling today?</p>
+        <p className="mb-2 text-base leading-relaxed">How are you feeling today?</p>
         <div className="flex items-center gap-3">
           {moodEmojis.map((emoji, index) => (
             <button
@@ -50,7 +50,7 @@ export default function MoodEntry() {
 
 
       <div>
-        <label htmlFor="notes" className="block mb-1">
+        <label htmlFor="notes" className="block mb-1 text-base leading-relaxed">
           Notes (optional)
         </label>
         <textarea

--- a/src/pages/TherapyScheduler.tsx
+++ b/src/pages/TherapyScheduler.tsx
@@ -53,7 +53,7 @@ export default function TherapyScheduler() {
   };
 
   return (
-    <div className="p-4">
+    <div className="p-4 space-y-6">
       <h1 className="text-2xl font-bold mb-4">Therapy Scheduler</h1>
       <div className="flex items-center gap-2 mb-4">
         <input
@@ -66,7 +66,7 @@ export default function TherapyScheduler() {
           Add
         </button>
       </div>
-      <ul className="space-y-2">
+      <ul className="space-y-2 mt-4">
         {times.map((time) => (
           <li key={time} className="flex items-center gap-2">
             <span className="flex-1">{time}</span>
@@ -78,7 +78,9 @@ export default function TherapyScheduler() {
             </button>
           </li>
         ))}
-        {times.length === 0 && <li>No times scheduled.</li>}
+        {times.length === 0 && (
+          <li className="text-base leading-relaxed">No times scheduled.</li>
+        )}
       </ul>
     </div>
   );

--- a/src/pages/__snapshots__/MoodEntry.a11y.test.tsx.snap
+++ b/src/pages/__snapshots__/MoodEntry.a11y.test.tsx.snap
@@ -2055,7 +2055,7 @@ exports[`MoodEntry accessibility > has no accessibility violations 1`] = `
               "relatedNodes": [],
             },
           ],
-          "html": "<h1 class="text-2xl font-bold">Mood Entry</h1>",
+          "html": "<h1 class="text-2xl font-bold mb-4">Mood Entry</h1>",
           "impact": null,
           "none": [],
           "target": [
@@ -2088,7 +2088,7 @@ exports[`MoodEntry accessibility > has no accessibility violations 1`] = `
               "message": "Form field does not have multiple label elements",
               "relatedNodes": [
                 {
-                  "html": "<label for="notes" class="block mb-1">Notes (optional)</label>",
+                  "html": "<label for="notes" class="block mb-1 text-base leading-relaxed">Notes (optional)</label>",
                   "target": [
                     "label",
                   ],
@@ -2138,7 +2138,7 @@ exports[`MoodEntry accessibility > has no accessibility violations 1`] = `
               "relatedNodes": [],
             },
           ],
-          "html": "<h1 class="text-2xl font-bold">Mood Entry</h1>",
+          "html": "<h1 class="text-2xl font-bold mb-4">Mood Entry</h1>",
           "impact": null,
           "none": [],
           "target": [
@@ -2201,7 +2201,7 @@ exports[`MoodEntry accessibility > has no accessibility violations 1`] = `
               "message": "Element has an explicit <label>",
               "relatedNodes": [
                 {
-                  "html": "<label for="notes" class="block mb-1">Notes (optional)</label>",
+                  "html": "<label for="notes" class="block mb-1 text-base leading-relaxed">Notes (optional)</label>",
                   "target": [
                     "label",
                   ],


### PR DESCRIPTION
## Summary
- adjust Calendar modal text sizes
- update Calendar layout spacing
- tune MoodEntry typography
- refine Customize labels
- tweak TherapyScheduler list style
- update accessibility test snapshot

## Testing
- `npm test -- -u`

------
https://chatgpt.com/codex/tasks/task_e_68533fa95034832fa32572f035592108