### PR TITLE
Compact notes textarea

### DIFF
--- a/src/pages/MoodEntry.tsx
+++ b/src/pages/MoodEntry.tsx
@@ -60,11 +60,9 @@ export default function MoodEntry() {
           id="notes"
           value={notes}
           onFocus={() => setRows(4)}
-          onBlur={() => {
-            if (notes === '') setRows(1);
-          }}
+          onBlur={() => setRows(1)}
           onChange={(e) => setNotes(e.target.value)}
-          className="w-full p-2 border rounded bg-creamWhite text-indigo dark:text-creamWhite transition-all"
+          className="w-full px-2 py-1 border rounded bg-creamWhite text-indigo dark:text-creamWhite transition-all"
           rows={rows}
         />
       </div>


### PR DESCRIPTION
## Summary
- shrink notes field to 1 row when not focused
- expand to 4 rows on focus
- reduce padding for a more compact textarea

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68534358f18c832f8b627f0e46cf6967