### PR TITLE
Add labels to Light Therapy Scheduler

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ browser.
   When geolocation is available the entry is tagged with your coordinates.
 - **Calendar** – view past entries on a monthly calendar and tap a day to see
   details.
-- **Therapy Scheduler** – set daily times to receive notifications reminding you
+- **Light Therapy Scheduler** – set daily times to receive notifications reminding you
   about therapy activities.
 - **Timer** – a simple countdown timer.
 - **Customization** – toggle dark mode, choose a seasonal theme (Spring, Summer,

--- a/src/components/PremiumModal.tsx
+++ b/src/components/PremiumModal.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 
 interface PremiumModalProps {
   onStart: () => void

--- a/src/contexts/useSchedulerStore.ts
+++ b/src/contexts/useSchedulerStore.ts
@@ -1,23 +1,32 @@
 import { create } from 'zustand';
 
+export interface ScheduledMoment {
+  time: string;
+  label: string;
+}
+
 interface SchedulerState {
-  times: string[];
-  addTime: (time: string) => void;
+  times: ScheduledMoment[];
+  addTime: (time: string, label: string) => void;
   removeTime: (time: string) => void;
 }
 
 const stored = localStorage.getItem('scheduledTimes');
-const initialTimes: string[] = stored ? JSON.parse(stored) : [];
+const initialTimes: ScheduledMoment[] = stored ? JSON.parse(stored) : [];
 
 export const useSchedulerStore = create<SchedulerState>((set, get) => ({
   times: initialTimes,
-  addTime: (time) => {
-    const updated = Array.from(new Set([...get().times, time])).sort();
-    localStorage.setItem('scheduledTimes', JSON.stringify(updated));
-    set({ times: updated });
+  addTime: (time, label) => {
+    const existing = get().times;
+    const updated = existing.some((t) => t.time === time)
+      ? existing.map((t) => (t.time === time ? { time, label } : t))
+      : [...existing, { time, label }];
+    const sorted = updated.sort((a, b) => a.time.localeCompare(b.time));
+    localStorage.setItem('scheduledTimes', JSON.stringify(sorted));
+    set({ times: sorted });
   },
   removeTime: (time) => {
-    const updated = get().times.filter((t) => t !== time);
+    const updated = get().times.filter((t) => t.time !== time);
     localStorage.setItem('scheduledTimes', JSON.stringify(updated));
     set({ times: updated });
   },

--- a/src/pages/TherapyScheduler.tsx
+++ b/src/pages/TherapyScheduler.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import { useSchedulerStore } from '../contexts/useSchedulerStore';
+import type { ScheduledMoment } from '../contexts/useSchedulerStore';
 
 export default function TherapyScheduler() {
   const { times, addTime, removeTime } = useSchedulerStore();
   const [newTime, setNewTime] = React.useState('12:00');
+  const [newLabel, setNewLabel] = React.useState('walk reminder');
 
   React.useEffect(() => {
     if (typeof window === 'undefined' || !('Notification' in window)) {
@@ -15,8 +17,8 @@ export default function TherapyScheduler() {
 
     const ids: number[] = [];
 
-    const schedule = (time: string) => {
-      const [h, m] = time.split(':').map(Number);
+    const schedule = (entry: ScheduledMoment) => {
+      const [h, m] = entry.time.split(':').map(Number);
       const now = new Date();
       const next = new Date();
       next.setHours(h, m, 0, 0);
@@ -47,14 +49,18 @@ export default function TherapyScheduler() {
   }, [times]);
 
   const handleAdd = () => {
-    if (newTime && !times.includes(newTime)) {
-      addTime(newTime);
+    if (newTime && !times.some((t) => t.time === newTime)) {
+      addTime(newTime, newLabel);
+      setNewLabel('walk reminder');
     }
   };
 
   return (
     <div className="p-4 space-y-6">
-      <h1 className="text-2xl font-bold mb-4">Therapy Scheduler</h1>
+      <h1 className="text-2xl font-bold mb-2">Light Therapy Scheduler</h1>
+      <p className="text-base leading-relaxed mb-2">
+        Set times to step outside for sunlight and feel your best.
+      </p>
       <div className="flex items-center gap-2 mb-4">
         <input
           type="time"
@@ -62,14 +68,26 @@ export default function TherapyScheduler() {
           onChange={(e) => setNewTime(e.target.value)}
           className="border p-2 rounded text-indigo dark:text-creamWhite"
         />
+        <input
+          type="text"
+          value={newLabel}
+          onChange={(e) => setNewLabel(e.target.value)}
+          className="border p-2 rounded text-indigo dark:text-creamWhite"
+          placeholder="label"
+        />
         <button onClick={handleAdd} className="px-4 py-2 bg-primary-dark text-white rounded">
           Add
         </button>
       </div>
       <ul className="space-y-2 mt-4">
-        {times.map((time) => (
+        {times.map(({ time, label }) => (
           <li key={time} className="flex items-center gap-2">
-            <span className="flex-1">{time}</span>
+            <span className="flex-1">
+              {time}
+              {label && (
+                <span className="ml-2 text-sm text-indigo dark:text-yellow">{label}</span>
+              )}
+            </span>
             <button
               onClick={() => removeTime(time)}
               className="px-2 py-1 bg-yellow text-indigo rounded"
@@ -79,7 +97,9 @@ export default function TherapyScheduler() {
           </li>
         ))}
         {times.length === 0 && (
-          <li className="text-base leading-relaxed">No times scheduled.</li>
+          <li className="text-base leading-relaxed">
+            You haven’t set any sunlight moments yet ☁️
+          </li>
         )}
       </ul>
     </div>


### PR DESCRIPTION
## Summary
- rename Therapy Scheduler to **Light Therapy Scheduler**
- support labels for each scheduled moment
- display new empty state when no times are set
- update README
- clean up unused React import

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68542522add8832fb1ff8f11c9260187