### PR TITLE
Update customization and theme handling

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -40,6 +40,15 @@ function InnerApp() {
   const PREMIUM_DAYS = 7;
 
   React.useEffect(() => {
+    const root = document.documentElement;
+    if (dark) {
+      root.classList.add('dark');
+    } else {
+      root.classList.remove('dark');
+    }
+  }, [dark]);
+
+  React.useEffect(() => {
     if (
       !shown &&
       location.pathname !== '/permissions' &&

--- a/src/components/MoodAnalytics.tsx
+++ b/src/components/MoodAnalytics.tsx
@@ -15,11 +15,13 @@ import type { ChartOptions } from 'chart.js'
 import { format } from 'date-fns'
 import { useMoodStore } from '../contexts/useMoodStore'
 import { computeWeeklySummary } from '../contexts/analytics'
+import { useThemeStore } from '../contexts/useThemeStore'
 
 ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Title, Tooltip, Legend)
 
 export default function MoodAnalytics() {
   const entries = useMoodStore((state) => state.entries)
+  const dark = useThemeStore((state) => state.dark)
 
   const labels = entries.map((e) => format(e.timestamp, 'MM/dd'))
   const moodData = entries.map((e) => e.mood)
@@ -54,14 +56,18 @@ export default function MoodAnalytics() {
     ],
   }
 
+  const tickColor = dark ? '#FFFDF8' : '#1D3557'
+  const gridColor = dark ? 'rgba(255,255,255,0.2)' : '#e5e7eb'
+  const tooltipBg = dark ? '#334155' : '#B7C9D4'
+
   const options: ChartOptions<'line'> = {
     events: ['click'],
     plugins: {
       legend: { display: false },
       tooltip: {
-        backgroundColor: '#B7C9D4',
-        titleColor: '#1D3557',
-        bodyColor: '#1D3557',
+        backgroundColor: tooltipBg,
+        titleColor: tickColor,
+        bodyColor: tickColor,
         callbacks: {
           afterBody: (ctx) => {
             const i = ctx[0]?.dataIndex ?? 0
@@ -77,6 +83,16 @@ export default function MoodAnalytics() {
             return [`Sunrise: ${sunrise}`, `Sunset: ${sunset}`, `Weather: ${weather}`]
           },
         },
+      },
+    },
+    scales: {
+      x: {
+        ticks: { color: tickColor },
+        grid: { color: gridColor },
+      },
+      y: {
+        ticks: { color: tickColor },
+        grid: { color: gridColor },
       },
     },
   }

--- a/src/contexts/useThemeStore.ts
+++ b/src/contexts/useThemeStore.ts
@@ -12,7 +12,7 @@ interface ThemeState {
 const initialDark = localStorage.getItem('themeDark') === 'true';
 const initialSeason = localStorage.getItem('seasonPreference') || 'Spring';
 const initialFrequency = parseInt(
-  localStorage.getItem('notificationFrequency') || '5',
+  localStorage.getItem('notificationFrequency') || '1',
   10
 );
 

--- a/src/pages/Customize.tsx
+++ b/src/pages/Customize.tsx
@@ -11,6 +11,7 @@ export default function Customize() {
     setNotificationFrequency,
   } = useThemeStore();
   const { reminderTime, setReminderTime } = useCheckInStore();
+  const frequencyLabels = ['Low', 'Medium', 'High'];
 
   return (
     <div className="p-4 space-y-6">
@@ -51,7 +52,8 @@ export default function Customize() {
           id="notification-range"
           type="range"
           min="0"
-          max="10"
+          max="2"
+          step="1"
           value={notificationFrequency}
           onChange={(e) => setNotificationFrequency(Number(e.target.value))}
           className="w-full"
@@ -61,6 +63,9 @@ export default function Customize() {
           <span>Medium</span>
           <span>High</span>
         </div>
+        <p className="text-center text-sm text-mutedBlueGray mt-1">
+          {frequencyLabels[notificationFrequency]}
+        </p>
       </div>
 
       <div>
@@ -75,7 +80,7 @@ export default function Customize() {
           className="p-2 border rounded text-indigo dark:text-creamWhite"
         />
         <p className="mt-1 text-base leading-relaxed text-mutedBlueGray">
-          You’ll be reminded daily at {reminderTime}
+          You’ll be reminded daily at {reminderTime}.
         </p>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- tweak `Notification Frequency` slider to show Low/Medium/High
- show reminder time preview with a period
- default notification frequency set to Medium
- apply dark theme class on `<html>` so nav and charts update
- colorize charts to respond to theme

## Testing
- `npm run build` *(fails: cannot find some TS dependencies)*
- `npm run lint` *(fails: cannot find @eslint/js)*
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_685428986e44832faf03a1fe53f4609a