### PR TITLE
Add streak badge and quick mood button

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { BrowserRouter, Routes, Route, useLocation, useNavigate } from 'react-router-dom';
+import { BrowserRouter, Routes, Route, useLocation, useNavigate, Link } from 'react-router-dom';
 import NavBar from './components/NavBar';
 import Home from './pages/Home';
 import About from './pages/About';
@@ -169,6 +169,14 @@ function InnerApp() {
         Toggle Theme
       </button>
       <NavBar />
+      <div className="p-4">
+        <Link
+          to="/mood"
+          className="inline-block px-4 py-2 bg-primary-dark text-white rounded"
+        >
+          Log today’s mood
+        </Link>
+      </div>
       <Routes>
         <Route path="/" element={<WelcomeCarousel />} />
         <Route path="/permissions" element={<PermissionsPrompt />} />

--- a/src/components/StreakCounter.tsx
+++ b/src/components/StreakCounter.tsx
@@ -11,8 +11,12 @@ export default function StreakCounter() {
   return (
     <div className="mt-4 p-4 border rounded bg-creamWhite dark:bg-indigo">
       <h2 className="text-lg font-bold">Current Streak</h2>
-      <p className="text-2xl">
-        {streak} day{streak === 1 ? '' : 's'} {reward}
+      <p className="text-2xl flex items-center gap-1">
+        {streak} day{streak === 1 ? '' : 's'}
+        <span role="img" aria-label="streak badge">
+          🔥
+        </span>
+        {reward && <span>{reward}</span>}
       </p>
     </div>
   );


### PR DESCRIPTION
## Summary
- show a fire badge next to streak count
- add a quick link button to log today's mood under the navigation bar

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685429cd1fb8832fb8a4f9991bce8d8b