### PR TITLE
Fix therapy scheduler timeouts

### DIFF
--- a/src/pages/TherapyScheduler.tsx
+++ b/src/pages/TherapyScheduler.tsx
@@ -33,12 +33,14 @@ export default function TherapyScheduler() {
             body: 'It is time for your scheduled therapy activity.',
           });
         }
-        const id2 = window.setTimeout(trigger, 24 * 60 * 60 * 1000);
-        ids.push(id2);
       };
 
-      const id = window.setTimeout(trigger, delay);
-      ids.push(id);
+      const timeoutId = window.setTimeout(() => {
+        trigger();
+        const intervalId = window.setInterval(trigger, 24 * 60 * 60 * 1000);
+        ids.push(intervalId);
+      }, delay);
+      ids.push(timeoutId);
     };
 
     times.forEach(schedule);


### PR DESCRIPTION
## Summary
- prevent notifications from leaving stray timeouts by switching to `setInterval`

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68542c89df78832fa78224058d5ce286