### PR TITLE
Improve README and Jest config

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,28 @@
 
 This is an [Expo](https://expo.dev) project created with [`create-expo-app`](https://www.npmjs.com/package/create-expo-app).
 
+## Program overview
+
+This repository contains a small mood tracking app built with **React Native**
+and [Expo Router](https://expo.dev/router). It showcases a tab based
+navigation structure with three screens:
+
+- **Home** – a landing page with a simple "waving hand" animation.
+- **Explore** – demonstrates reusable components such as collapsible sections
+  and the `ParallaxScrollView` header.
+- **Calendar** – the main feature where mood entries are displayed on a
+  calendar. Selecting a marked day opens a modal to view or edit the entry.
+
+Mood entries are persisted with
+`@react-native-async-storage/async-storage`. Sample data is loaded on first
+launch so the calendar is populated with entries. The entry modal uses
+`react-native-reanimated` and `react-native-gesture-handler` for drag to dismiss
+interactions.
+
+All screens reside in the `app/` directory and are wired up automatically
+through file based routing. Shared hooks live in `hooks/` and reusable UI
+components can be found in `components/`.
+
 ## Get started
 
 1. Install dependencies
@@ -47,6 +69,15 @@ Install them together with the rest of the dependencies and then start the app:
 ```bash
 npm install
 npx expo start
+```
+
+### Running tests
+
+Unit tests cover the calendar screen, modal behaviour and storage utilities. Run
+them with:
+
+```bash
+npm test
 ```
 
 ## Get a fresh project

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,10 @@
 module.exports = {
-  preset: 'ts-jest',
+  preset: 'jest-expo',
   testEnvironment: 'jsdom',
   setupFilesAfterEnv: ['@testing-library/jest-native/extend-expect'],
+  transform: {
+    '^.+\\.[jt]sx?$': 'babel-jest',
+  },
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/$1',
     'react-native-reanimated': 'react-native-reanimated/mock',


### PR DESCRIPTION
## Summary
- document project in more detail
- add testing section in README
- configure Jest using `jest-expo`

## Testing
- `npm test` *(fails: ReferenceError trying to import Expo modules)*

------
https://chatgpt.com/codex/tasks/task_e_6865adb426c4832f85e7273aa61201c4