### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: CI
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run lint
+      - run: npm test
+      - run: npm run build


### PR DESCRIPTION
## Summary
- set up GitHub Actions workflow for linting, testing and building

## Testing
- `npm ci`
- `npm run lint`
- `npm test` *(fails: Snapshot `MoodEntry accessibility > has no accessibility violations 1` mismatched)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6866caf9eab8832fa78504d8d7f074fc