### PR TITLE
Auto-register service worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,8 @@ npm install -D vite-plugin-pwa
 ```
 
 The default configuration registers the worker automatically when visiting the
-site.
+site. The service worker is registered from `src/main.tsx` using
+`registerSW({ immediate: true })` so it starts right away.
 
 ## Production Deployment
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,7 +1,10 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import { registerSW } from 'virtual:pwa-register'
 import './index.css'
 import App from './App.tsx'
+
+registerSW({ immediate: true })
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>


### PR DESCRIPTION
## Summary
- register the PWA service worker from `src/main.tsx`
- document automatic service worker registration

## Testing
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6866d9f31058832fb97477ebc8d826ec