### PR TITLE
Add scheduled notification worker

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -84,44 +84,12 @@ function InnerApp() {
 
   React.useEffect(() => {
     if (typeof window === 'undefined' || !('Notification' in window)) {
-      return;
+      return
     }
     if (Notification.permission === 'default') {
-      void Notification.requestPermission();
+      void Notification.requestPermission()
     }
-
-    let dailyId: number | undefined;
-
-    const schedule = () => {
-      const [h, m] = reminderTime.split(':').map(Number);
-      const now = new Date();
-      const next = new Date();
-      next.setHours(h, m, 0, 0);
-      if (next.getTime() <= now.getTime()) {
-        next.setDate(next.getDate() + 1);
-      }
-      const delay = next.getTime() - now.getTime();
-
-      const trigger = () => {
-        if (Notification.permission === 'granted') {
-          new Notification('Daily Check-In', {
-            body: "It's time for your daily mood check-in.",
-          });
-        }
-        dailyId = window.setTimeout(trigger, 24 * 60 * 60 * 1000);
-      };
-
-      dailyId = window.setTimeout(trigger, delay);
-    };
-
-    schedule();
-
-    return () => {
-      if (dailyId !== undefined) {
-        clearTimeout(dailyId);
-      }
-    };
-  }, [reminderTime]);
+  }, [])
 
   const handleCheckIn = () => {
     setLastPrompt(Date.now());

--- a/src/contexts/useCheckInStore.test.ts
+++ b/src/contexts/useCheckInStore.test.ts
@@ -1,0 +1,31 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useCheckInStore } from './useCheckInStore'
+
+declare global {
+  interface Navigator {
+    serviceWorker: {
+      ready: Promise<{ active: { postMessage: (data: unknown) => void } }>
+    }
+  }
+}
+
+let postMessage: (data: unknown) => void
+
+beforeEach(() => {
+  localStorage.clear()
+  postMessage = vi.fn()
+  global.navigator = {
+    serviceWorker: {
+      ready: Promise.resolve({ active: { postMessage } }),
+    },
+  } as unknown as Navigator
+})
+
+describe('useCheckInStore', () => {
+  it('posts reminder time to the service worker', async () => {
+    const store = useCheckInStore.getState()
+    store.setReminderTime('10:15')
+    await Promise.resolve()
+    expect(postMessage).toHaveBeenCalledWith({ type: 'set-reminder', time: '10:15' })
+  })
+})

--- a/src/contexts/useCheckInStore.ts
+++ b/src/contexts/useCheckInStore.ts
@@ -1,4 +1,13 @@
-import { create } from 'zustand';
+import { create } from 'zustand'
+
+function scheduleReminder(time: string): void {
+  if (typeof window === 'undefined' || !('serviceWorker' in navigator)) return
+  navigator.serviceWorker.ready
+    .then((reg) => {
+      reg.active?.postMessage({ type: 'set-reminder', time })
+    })
+    .catch(() => {})
+}
 
 interface CheckInState {
   lastPrompt: number;
@@ -23,5 +32,8 @@ export const useCheckInStore = create<CheckInState>((set) => ({
   setReminderTime: (time) => {
     localStorage.setItem('checkInReminderTime', time);
     set({ reminderTime: time });
+    scheduleReminder(time);
   },
 }));
+
+scheduleReminder(initialTime);

--- a/src/sw-notifications.ts
+++ b/src/sw-notifications.ts
@@ -1,0 +1,38 @@
+self.addEventListener('install', () => self.skipWaiting())
+self.addEventListener('activate', (event) => {
+  event.waitUntil(self.clients.claim())
+})
+
+self.addEventListener('message', (event) => {
+  const { type, time } = event.data || {}
+  if (type === 'set-reminder' && typeof time === 'string') {
+    const [h, m] = time.split(':').map((v) => parseInt(v, 10))
+    const now = new Date()
+    const next = new Date()
+    next.setHours(h, m, 0, 0)
+    if (next.getTime() <= now.getTime())
+      next.setDate(next.getDate() + 1)
+    // @ts-ignore: TimestampTrigger is not yet typed in TS lib
+    const Trigger = (self as any).TimestampTrigger
+    if (Trigger && 'showTrigger' in Notification.prototype) {
+      self.registration.showNotification('Daily Check-In', {
+        body: "It's time for your daily mood check-in.",
+        // @ts-ignore: TimestampTrigger is not yet typed in TS lib
+        showTrigger: new Trigger(next.getTime()),
+      })
+    }
+  }
+})
+
+self.addEventListener('notificationclick', (event) => {
+  event.notification.close()
+  event.waitUntil(
+    self.clients.matchAll({ type: 'window', includeUncontrolled: true }).then((clients) => {
+      for (const client of clients) {
+        if ('focus' in client) return client.focus()
+      }
+      if (self.clients.openWindow)
+        return self.clients.openWindow('/mood')
+    }),
+  )
+})

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,7 +4,14 @@ import { VitePWA } from 'vite-plugin-pwa'
 
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [react(), VitePWA({ registerType: 'autoUpdate' })],
+  plugins: [
+    react(),
+    VitePWA({
+      registerType: 'autoUpdate',
+      srcDir: 'src',
+      filename: 'sw-notifications.ts',
+    }),
+  ],
   test: {
     environment: 'jsdom',
   },


### PR DESCRIPTION
## Summary
- add a service worker `sw-notifications.ts` that schedules check‑in reminders
- wire VitePWA to use the new worker
- update `useCheckInStore` to post reminder times to the worker
- drop old timeout-based notification logic from `App`
- add unit test for the store to verify worker communication

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6866dbd031dc832f89b61d29912791b5