### PR TITLE
Add PWA install prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,10 @@ The default configuration registers the worker automatically when visiting the
 site. The service worker is registered from `src/main.tsx` using
 `registerSW({ immediate: true })` so it starts right away.
 
+When the browser fires the `beforeinstallprompt` event the navigation bar shows
+an **Install** button. Selecting it triggers the stored event so users can add
+the app to their home screen.
+
 ## Production Deployment
 
 Running `npm run build` outputs a static `dist/` directory that can be served by

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -25,7 +25,7 @@ function InnerApp() {
   const { dark, toggle, season } = useThemeStore();
   const colors = getSeasonColors(season);
   const { shown } = usePermissionStore();
-  const { lastPrompt, setLastPrompt, reminderTime } = useCheckInStore();
+  const { lastPrompt, setLastPrompt } = useCheckInStore();
   const location = useLocation();
   const navigate = useNavigate();
   const [showCheckIn, setShowCheckIn] = React.useState(false);

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -1,8 +1,25 @@
 import React from 'react';
 import { NavLink } from 'react-router-dom';
 
+interface BeforeInstallPromptEvent extends Event {
+  prompt: () => Promise<void>;
+  userChoice: Promise<{ outcome: 'accepted' | 'dismissed'; platform: string }>;
+}
+
 export default function NavBar() {
   const [open, setOpen] = React.useState(false);
+  const [promptEvent, setPromptEvent] = React.useState<
+    BeforeInstallPromptEvent | null
+  >(null);
+
+  React.useEffect(() => {
+    const handler = (e: BeforeInstallPromptEvent) => {
+      e.preventDefault();
+      setPromptEvent(e);
+    };
+    window.addEventListener('beforeinstallprompt', handler);
+    return () => window.removeEventListener('beforeinstallprompt', handler);
+  }, []);
 
   const linkClass = ({ isActive }: { isActive: boolean }) =>
     [
@@ -78,6 +95,17 @@ export default function NavBar() {
       >
         Analytics
       </NavLink>
+      {promptEvent && (
+        <button
+          onClick={() => {
+            promptEvent.prompt();
+            setPromptEvent(null);
+          }}
+          className="block px-2 py-1 rounded text-indigo dark:text-yellow hover:bg-mutedBlueGray dark:hover:bg-indigo"
+        >
+          Install
+        </button>
+      )}
     </>
   );
 
@@ -93,7 +121,9 @@ export default function NavBar() {
         </button>
       </div>
       <div className="hidden md:flex gap-4">{links}</div>
-      {open && <div className="flex flex-col gap-2 mt-2 md:hidden">{links}</div>}
+      {open && (
+        <div className="flex flex-col gap-2 mt-2 md:hidden">{links}</div>
+      )}
     </nav>
   );
 }

--- a/src/sw-notifications.ts
+++ b/src/sw-notifications.ts
@@ -12,12 +12,14 @@ self.addEventListener('message', (event) => {
     next.setHours(h, m, 0, 0)
     if (next.getTime() <= now.getTime())
       next.setDate(next.getDate() + 1)
-    // @ts-ignore: TimestampTrigger is not yet typed in TS lib
-    const Trigger = (self as any).TimestampTrigger
+    // @ts-expect-error TimestampTrigger is not yet typed in TS lib
+    const Trigger = (self as unknown as {
+      TimestampTrigger: new (ts: number) => unknown
+    }).TimestampTrigger
     if (Trigger && 'showTrigger' in Notification.prototype) {
       self.registration.showNotification('Daily Check-In', {
         body: "It's time for your daily mood check-in.",
-        // @ts-ignore: TimestampTrigger is not yet typed in TS lib
+        // @ts-expect-error TimestampTrigger is not yet typed in TS lib
         showTrigger: new Trigger(next.getTime()),
       })
     }


### PR DESCRIPTION
## Summary
- hook beforeinstallprompt in `NavBar`
- show Install button when prompt is available
- fix lint issues in `sw-notifications` and `App`
- document installing the PWA

## Testing
- `npm run lint`
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_6866e86ce12c832fb7e867ab2d143154